### PR TITLE
Make every formatter optional

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Use `pre-commit install` to install the pre-commit hook for the repository.
 - Implement a Formatter by inheriting from `pydocstringformatter.formatting.Formatter`
 - Add your new formatter to `pydocstringformatter.formatting.FORMATTERS`
 - Write a clear docstring because this will be user-facing: it's what will be seen in
-  the help message for the formatters command line option.
+  the help message for the formatter's command line option.
 - Choose a proper name because this will be user-facing: the name will be used to turn
-  the checker on and off via the command line or config files.
+  the formatter on and off via the command line or config files.
 
 ### Testing
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,8 +8,10 @@ Use `pre-commit install` to install the pre-commit hook for the repository.
 
 - Implement a Formatter by inheriting from `pydocstringformatter.formatting.Formatter`
 - Add your new formatter to `pydocstringformatter.formatting.FORMATTERS`
-- Choose a proper name because this will be user-facing: the name will be used for
-  options of the CLI.
+- Write a clear docstring because this will be user-facing: it's what will be seen in
+  the help message for the formatters command line option.
+- Choose a proper name because this will be user-facing: the name will be used to turn
+  the checker on and off via the command line or config files.
 
 ### Testing
 

--- a/pydocstringformatter/run.py
+++ b/pydocstringformatter/run.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import List, Union
 
 from pydocstringformatter import __version__, formatting, utils
+from pydocstringformatter.formatting import FORMATTERS
 
 
 class _Run:
@@ -16,6 +17,7 @@ class _Run:
 
     def __init__(self, argv: Union[List[str], None]) -> None:
         self.arg_parser = utils._register_arguments(__version__)
+        utils._register_arguments_formatters(self.arg_parser, FORMATTERS)
         self.config = argparse.Namespace()
 
         if argv := argv or sys.argv[1:]:
@@ -47,9 +49,11 @@ class _Run:
         for index, tokeninfo in enumerate(tokens):
             new_tokeninfo = tokeninfo
 
+            formatter_options = vars(self.config)
             if utils._is_docstring(new_tokeninfo, tokens[index - 1]):
                 for formatter in formatting.FORMATTERS:
-                    new_tokeninfo = formatter.treat_token(new_tokeninfo)
+                    if formatter_options[formatter.name]:
+                        new_tokeninfo = formatter.treat_token(new_tokeninfo)
             changed_tokens.append(new_tokeninfo)
 
             if tokeninfo != new_tokeninfo:

--- a/pydocstringformatter/run.py
+++ b/pydocstringformatter/run.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import List, Union
 
 from pydocstringformatter import __version__, formatting, utils
-from pydocstringformatter.formatting import FORMATTERS
 
 
 class _Run:
@@ -17,13 +16,13 @@ class _Run:
 
     def __init__(self, argv: Union[List[str], None]) -> None:
         self.arg_parser = utils._register_arguments(__version__)
-        utils._register_arguments_formatters(self.arg_parser, FORMATTERS)
+        utils._register_arguments_formatters(self.arg_parser, formatting.FORMATTERS)
         self.config = argparse.Namespace()
 
         if argv := argv or sys.argv[1:]:
-            utils._parse_toml_file(self.arg_parser, self.config)
-            utils._parse_command_line_arguments(self.arg_parser, argv, self.config)
-
+            utils._parse_options(
+                self.arg_parser, self.config, argv, formatting.FORMATTERS
+            )
             self._check_files(self.config.files)
         else:
             self.arg_parser.print_help()

--- a/pydocstringformatter/run.py
+++ b/pydocstringformatter/run.py
@@ -48,10 +48,9 @@ class _Run:
         for index, tokeninfo in enumerate(tokens):
             new_tokeninfo = tokeninfo
 
-            formatter_options = vars(self.config)
             if utils._is_docstring(new_tokeninfo, tokens[index - 1]):
                 for formatter in formatting.FORMATTERS:
-                    if formatter_options[formatter.name]:
+                    if getattr(self.config, formatter.name):
                         new_tokeninfo = formatter.treat_token(new_tokeninfo)
             changed_tokens.append(new_tokeninfo)
 

--- a/pydocstringformatter/utils/__init__.py
+++ b/pydocstringformatter/utils/__init__.py
@@ -1,6 +1,5 @@
 from pydocstringformatter.utils.argument_parsing import (
-    _parse_command_line_arguments,
-    _parse_toml_file,
+    _parse_options,
     _register_arguments,
     _register_arguments_formatters,
 )
@@ -18,12 +17,11 @@ __all__ = [
     "_find_python_files",
     "_generate_diff",
     "_is_docstring",
-    "_parse_command_line_arguments",
-    "_parse_toml_file",
     "ParsingError",
     "PydocstringFormatterError",
     "_register_arguments",
     "_register_arguments_formatters",
     "TomlParsingError",
+    "_parse_options",
     "_print_to_console",
 ]

--- a/pydocstringformatter/utils/__init__.py
+++ b/pydocstringformatter/utils/__init__.py
@@ -2,6 +2,7 @@ from pydocstringformatter.utils.argument_parsing import (
     _parse_command_line_arguments,
     _parse_toml_file,
     _register_arguments,
+    _register_arguments_formatters,
 )
 from pydocstringformatter.utils.exceptions import (
     ParsingError,
@@ -22,6 +23,7 @@ __all__ = [
     "ParsingError",
     "PydocstringFormatterError",
     "_register_arguments",
+    "_register_arguments_formatters",
     "TomlParsingError",
     "_print_to_console",
 ]

--- a/pydocstringformatter/utils/argument_parsing.py
+++ b/pydocstringformatter/utils/argument_parsing.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 import tomli
 
+from pydocstringformatter.formatting.base import Formatter
 from pydocstringformatter.utils.exceptions import TomlParsingError, UnrecognizedOption
 
 OPTIONS_TYPES = {"write": "store_true"}
@@ -36,7 +37,26 @@ def _register_arguments(version: str) -> argparse.ArgumentParser:
         version=version,
         help="Show version number and exit",
     )
+    return parser
 
+
+def _register_arguments_formatters(
+    parser: argparse.ArgumentParser, formatters: List[Formatter]
+) -> argparse.ArgumentParser:
+    """Register a list of formatters, so they can all be deactivated or activated."""
+    for formatter in formatters:
+        name = formatter.name
+        help_text = f"ctivate the {name} formatter"
+        parser.add_argument(
+            f"--{name}",
+            action="store_true",
+            dest=name,
+            default=not formatter.optional,
+            help=f"A{help_text} : {formatter.__doc__}",
+        )
+        parser.add_argument(
+            f"--no-{name}", action="store_false", dest=name, help=f"Dea{help_text}"
+        )
     return parser
 
 

--- a/pydocstringformatter/utils/argument_parsing.py
+++ b/pydocstringformatter/utils/argument_parsing.py
@@ -51,7 +51,6 @@ def _register_arguments_formatters(
             f"--{name}",
             action="store_true",
             dest=name,
-            default=not formatter.optional,
             help=f"A{help_text} : {formatter.__doc__}",
         )
         parser.add_argument(
@@ -100,3 +99,37 @@ def _parse_toml_file(
             arguments += _parse_toml_option(key, value)
 
         parser.parse_args(arguments, namespace)
+
+
+def _load_formatters_default_option(
+    parser: argparse.ArgumentParser,
+    namespace: argparse.Namespace,
+    formatters: List[Formatter],
+) -> None:
+    """Load the list of formatters based on their 'optional' attribute."""
+    arguments: List[str] = []
+    for formatter in formatters:
+        if formatter.optional:
+            arguments.append(f"--no-{formatter.name}")
+        elif not formatter.optional:
+            arguments.append(f"--{formatter.name}")
+
+    parser.parse_known_args(arguments, namespace)
+
+
+def _parse_options(
+    parser: argparse.ArgumentParser,
+    namespace: argparse.Namespace,
+    argv: List[str],
+    formatters: List[Formatter],
+) -> None:
+    """Load all default option values.
+
+    The order of parsing is:
+    1. default values, 2. configuration files, 3. command line arguments.
+    """
+    _load_formatters_default_option(parser, namespace, formatters)
+
+    _parse_toml_file(parser, namespace)
+
+    _parse_command_line_arguments(parser, argv, namespace)

--- a/pydocstringformatter/utils/argument_parsing.py
+++ b/pydocstringformatter/utils/argument_parsing.py
@@ -106,7 +106,7 @@ def _load_formatters_default_option(
     namespace: argparse.Namespace,
     formatters: List[Formatter],
 ) -> None:
-    """Load the list of formatters based on their 'optional' attribute."""
+    """Parse the state of the list of formatters based on their 'optional' attribute."""
     arguments: List[str] = []
     for formatter in formatters:
         if formatter.optional:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -3,7 +3,6 @@ import os
 import sys
 from pathlib import Path
 from typing import List
-from unittest.mock import patch
 
 import pytest
 
@@ -12,11 +11,13 @@ from pydocstringformatter.formatting import FORMATTERS
 
 
 def test_no_arguments(capsys: pytest.CaptureFixture[str]) -> None:
-    """Test that we warn when no arguments are provided"""
+    """Test that we display a help message when no arguments are provided."""
     sys.argv = ["pydocstringformatter"]
     pydocstringformatter.run_docstring_formatter()
     out, err = capsys.readouterr()
     assert out.startswith("usage: pydocstringformatter [-h]")
+
+    # Test that we print help messages for individual formatters as well
     assert "--beginning-quotes" in out
     assert "Activate the beginning-quotes formatter" in out
     assert "--no-beginning-quotes" in out
@@ -128,11 +129,10 @@ def test_optional_formatters(
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
-    """Test that optional check are activated or not depending on options."""
+    """Test that (optional) formatters are activated or not depending on options."""
     bad_docstring = tmp_path / "bad_docstring.py"
     bad_docstring.write_text(f'"""{"a" * 120}\n{"b" * 120}"""')
-    with patch.object(sys, "argv", ["pydocstringformatter", str(bad_docstring)] + args):
-        pydocstringformatter.run_docstring_formatter()
+    pydocstringformatter.run_docstring_formatter([str(bad_docstring)] + args)
     out, err = capsys.readouterr()
     assert not err
     if should_format:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -2,19 +2,26 @@
 import os
 import sys
 from pathlib import Path
+from typing import List
+from unittest.mock import patch
 
 import pytest
 
 import pydocstringformatter
+from pydocstringformatter.formatting import FORMATTERS
 
 
 def test_no_arguments(capsys: pytest.CaptureFixture[str]) -> None:
     """Test that we warn when no arguments are provided"""
     sys.argv = ["pydocstringformatter"]
     pydocstringformatter.run_docstring_formatter()
-    output = capsys.readouterr()
-    assert output.out.startswith("usage: pydocstringformatter [-h]")
-    assert not output.err
+    out, err = capsys.readouterr()
+    assert out.startswith("usage: pydocstringformatter [-h]")
+    assert "--beginning-quotes" in out
+    assert "Activate the beginning-quotes formatter" in out
+    assert "--no-beginning-quotes" in out
+    assert "Deactivate the beginning-quotes formatter" in out
+    assert not err
 
 
 def test_sys_agv_as_arguments(
@@ -106,3 +113,33 @@ Formatted {expected_second_path} 📖
 """
     )
     assert not output.err
+
+
+@pytest.mark.parametrize(
+    "args,should_format",
+    [
+        [[f"--no-{f.name}" for f in FORMATTERS], False],
+        [[f"--{f.name}" for f in FORMATTERS], True],
+    ],
+)
+def test_optional_formatters(
+    args: List[str],
+    should_format: bool,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Test that optional check are activated or not depending on options."""
+    bad_docstring = tmp_path / "bad_docstring.py"
+    bad_docstring.write_text(f'"""{"a" * 120}\n{"b" * 120}"""')
+    with patch.object(sys, "argv", ["pydocstringformatter", str(bad_docstring)] + args):
+        pydocstringformatter.run_docstring_formatter()
+    out, err = capsys.readouterr()
+    assert not err
+    if should_format:
+        msg = "Nothing was modified, but all formatters are activated."
+        assert "Nothing to do!" not in out
+        expected = ["---", "@@", "+++"]
+        assert all(e in out for e in expected), msg
+    else:
+        msg = "Something was modified, but all formatter are deactivated."
+        assert "Nothing to do!" in out, msg


### PR DESCRIPTION
Work in progress, this still need more robust tests. This would permit to automatically generate the arguments and to activate or deactivate every parser while still having a default.