### PR TITLE
Print out ``diff`` instead of complete file for formatting changes

### DIFF
--- a/pydocstringformatter/run.py
+++ b/pydocstringformatter/run.py
@@ -58,7 +58,7 @@ class _Run:
         if is_changed:
             try:
                 filename_str = os.path.relpath(filename)
-            except ValueError:
+            except ValueError:  # pragma: no cover # Covered on Windows
                 # On Windows relpath raises ValueError's when the mounts differ
                 filename_str = str(filename)
 

--- a/pydocstringformatter/run.py
+++ b/pydocstringformatter/run.py
@@ -56,16 +56,24 @@ class _Run:
                 is_changed = True
 
         if is_changed:
+            try:
+                filename_str = os.path.relpath(filename)
+            except ValueError:
+                # On Windows relpath raises ValueError's when the mounts differ
+                filename_str = str(filename)
+
             if self.config.write:
                 with open(filename, "w", encoding="utf-8") as file:
                     file.write(tokenize.untokenize(changed_tokens))
-                try:
-                    print(f"Formatted {os.path.relpath(filename)} 📖")
-                except ValueError:  # pragma: no cover
-                    # On Windows relpath raises ValueError's when mounts differ
-                    print(f"Formatted {filename} 📖")
+                    print(f"Formatted {filename_str} 📖")
             else:
-                sys.stdout.write(tokenize.untokenize(changed_tokens))
+                sys.stdout.write(
+                    utils._generate_diff(
+                        tokenize.untokenize(tokens),
+                        tokenize.untokenize(changed_tokens),
+                        filename_str,
+                    )
+                )
 
         return is_changed
 

--- a/pydocstringformatter/utils/__init__.py
+++ b/pydocstringformatter/utils/__init__.py
@@ -8,6 +8,7 @@ from pydocstringformatter.utils.exceptions import (
     PydocstringFormatterError,
     TomlParsingError,
 )
+from pydocstringformatter.utils.file_diference import _generate_diff
 from pydocstringformatter.utils.find_docstrings import _is_docstring
 from pydocstringformatter.utils.find_python_file import _find_python_files
 
@@ -20,4 +21,5 @@ __all__ = [
     "ParsingError",
     "_parse_toml_file",
     "TomlParsingError",
+    "_generate_diff",
 ]

--- a/pydocstringformatter/utils/file_diference.py
+++ b/pydocstringformatter/utils/file_diference.py
@@ -1,0 +1,14 @@
+import difflib
+
+
+def _generate_diff(old: str, new: str, filename: str) -> str:
+    """Generate a printable diff for two strings of sourcecode."""
+    return "\n".join(
+        difflib.unified_diff(
+            old.split("\n"),
+            new.split("\n"),
+            fromfile=filename,
+            tofile=filename,
+            lineterm="",
+        )
+    )

--- a/tests/data/format/no_changes/multi_line_variables.py.out
+++ b/tests/data/format/no_changes/multi_line_variables.py.out
@@ -1,1 +1,6 @@
-Nothing to do! All docstrings are correct 🎉
+var = """A multi-line
+docstring"""
+
+var = """A multi-line
+docstring
+"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,7 +17,9 @@ def test_no_toml(
     monkeypatch.chdir(CONFIG_DATA / "no_toml")
     pydocstringformatter.run_docstring_formatter(["test_package"])
     output = capsys.readouterr()
-    assert output.out == '"""A docstring"""\n'
+    assert output.out.endswith(
+        '@@ -1,3 +1,2 @@\n-"""\n-A docstring"""\n+"""A docstring"""\n '
+    )
     assert not output.err
 
 
@@ -39,7 +41,9 @@ def test_valid_toml_two(
     monkeypatch.chdir(CONFIG_DATA / "valid_toml_two")
     pydocstringformatter.run_docstring_formatter(["test_package"])
     output = capsys.readouterr()
-    assert output.out == '"""A docstring"""\n'
+    assert output.out.endswith(
+        '@@ -1,3 +1,2 @@\n-"""\n-A docstring"""\n+"""A docstring"""\n '
+    )
     assert not output.err
 
 
@@ -65,7 +69,9 @@ def test_no_write_argument(capsys: pytest.CaptureFixture[str], test_file: str) -
         assert "".join(file.readlines()) == '"""A multi-line\ndocstring"""'
 
     output = capsys.readouterr()
-    assert output.out == '"""A multi-line\ndocstring\n"""'
+    assert output.out.endswith(
+        '@@ -1,2 +1,3 @@\n """A multi-line\n-docstring"""\n+docstring\n+"""'
+    )
     assert not output.err
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,12 @@ def test_no_toml(
     pydocstringformatter.run_docstring_formatter(["test_package"])
     output = capsys.readouterr()
     assert output.out.endswith(
-        '@@ -1,3 +1,2 @@\n-"""\n-A docstring"""\n+"""A docstring"""\n '
+        '''
+@@ -1,3 +1,2 @@
+-"""
+-A docstring"""
++"""A docstring"""
+ '''
     )
     assert not output.err
 
@@ -42,7 +47,12 @@ def test_valid_toml_two(
     pydocstringformatter.run_docstring_formatter(["test_package"])
     output = capsys.readouterr()
     assert output.out.endswith(
-        '@@ -1,3 +1,2 @@\n-"""\n-A docstring"""\n+"""A docstring"""\n '
+        '''
+@@ -1,3 +1,2 @@
+-"""
+-A docstring"""
++"""A docstring"""
+ '''
     )
     assert not output.err
 
@@ -70,7 +80,11 @@ def test_no_write_argument(capsys: pytest.CaptureFixture[str], test_file: str) -
 
     output = capsys.readouterr()
     assert output.out.endswith(
-        '@@ -1,2 +1,3 @@\n """A multi-line\n-docstring"""\n+docstring\n+"""'
+        '''
+@@ -1,2 +1,3 @@
+ """A multi-line
+-docstring"""
++docstring\n+"""'''
     )
     assert not output.err
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 from pathlib import Path
 from typing import List
 
@@ -25,10 +26,29 @@ for dirname, _, files in os.walk(TEST_DATA):
     TESTS,
     ids=TEST_NAMES,
 )
-def test_formatting(test_file: str, capsys: pytest.CaptureFixture[str]) -> None:
-    """Test that we correctly format all files in the format directory"""
-    pydocstringformatter.run_docstring_formatter([test_file])
+def test_formatting(
+    test_file: str, capsys: pytest.CaptureFixture[str], tmp_path: pathlib.Path
+) -> None:
+    """Test that we correctly format all files in the format directory.
+
+    We create and write to a temporary file so that the original test file
+    isn't overwritten and the 'py.out' file can represent an actual
+    python file instead of a diff.
+    """
+    # Setup
+    temp_file_name = str(tmp_path / "test_file.py")
+    with open(test_file + ".out", encoding="utf-8") as expected_output:
+        expected_lines = expected_output.readlines()
+
+    # Get original lines from test file and write to temporary file
+    with open(test_file, encoding="utf-8") as original_file:
+        original_lines = original_file.readlines()
+    with open(temp_file_name, "w", encoding="utf-8") as temp_file:
+        temp_file.writelines(original_lines)
+
+    pydocstringformatter.run_docstring_formatter([temp_file_name, "--write"])
+
     output = capsys.readouterr()
     assert not output.err
-    with open(test_file + ".out", encoding="utf-8") as expected_output:
-        assert output.out == "".join(expected_output.readlines())
+    with open(temp_file_name, encoding="utf-8") as temp_file:
+        assert temp_file.readlines() == expected_lines

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -28,7 +28,9 @@ def test_sys_agv_as_arguments(
         assert "".join(file.readlines()) == '"""A multi-line\ndocstring"""'
 
     output = capsys.readouterr()
-    assert output.out == '"""A multi-line\ndocstring\n"""'
+    assert output.out.endswith(
+        '@@ -1,2 +1,3 @@\n """A multi-line\n-docstring"""\n+docstring\n+"""'
+    )
     assert not output.err
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -29,7 +29,12 @@ def test_sys_agv_as_arguments(
 
     output = capsys.readouterr()
     assert output.out.endswith(
-        '@@ -1,2 +1,3 @@\n """A multi-line\n-docstring"""\n+docstring\n+"""'
+        '''
+@@ -1,2 +1,3 @@
+ """A multi-line
+-docstring"""
++docstring
++"""'''
     )
     assert not output.err
 


### PR DESCRIPTION
Closes #2 

It's a bit annoying to have to check for `diffs` in the non-formatting unittests, but I think we can manage. If the `endswith` becomes too long we can always do `starswith("---")` although the `endswith` also provides a good sanity check that nothing is wrong with the actual diff.