### PR TITLE
Add an ``exclude`` option to exclude files based on ``glob`` patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,32 @@ pip install pydocstringformatter
 ## Usage
 
 ```shell
-usage: pydocstringformatter [-h] [-w] [-v] [files ...]
+usage: pydocstringformatter [-h] [-w] [--exclude EXCLUDE] [-v] [files ...]
 
 positional arguments:
   files
 
 options:
-  -h, --help     show this help message and exit
-  -w, --write    Write the changes to file instead of printing the diffs to stdout
-  -v, --version  Show version number and exit
+  -h, --help         show this help message and exit
+  -w, --write        Write the changes to file instead of printing the diffs to stdout
+  --exclude EXCLUDE  A comma separated list of glob patterns of file path names not to be formatted.
+  -v, --version      Show version number and exit
 ```
 
 ### Configuration
 
 Pydocstringformatter will also read any configuration added to the
 `[tool.pydocstringformatter]` section of a `pyproject.toml` file.
+
+For example:
+
+```toml
+[tool.pydocstringformatter]
+write = True
+exclude = "**/my_dir/**,**/my_other_dir/**"
+# Or:
+exclude = ["**/my_dir/**", "**/my_other_dir/**"]
+```
 
 ## Pre-commit
 

--- a/pydocstringformatter/configuration/arguments_manager.py
+++ b/pydocstringformatter/configuration/arguments_manager.py
@@ -6,6 +6,7 @@ from pydocstringformatter.configuration import (
     formatter_options,
     toml_parsing,
 )
+from pydocstringformatter.configuration.validators import VALIDATORS
 from pydocstringformatter.formatting.base import Formatter
 
 
@@ -33,6 +34,17 @@ class ArgumentsManager:
             "--write",
             action="store_true",
             help="Write the changes to file instead of printing the diffs to stdout",
+        )
+
+        self.parser.add_argument(
+            "--exclude",
+            action="store",
+            default=[""],
+            type=VALIDATORS["csv"],
+            help=(
+                "A comma separated list of glob patterns of "
+                "file path names not to be formatted."
+            ),
         )
 
         self.parser.add_argument(

--- a/pydocstringformatter/configuration/toml_parsing.py
+++ b/pydocstringformatter/configuration/toml_parsing.py
@@ -6,7 +6,7 @@ import tomli
 
 from pydocstringformatter.utils.exceptions import TomlParsingError, UnrecognizedOption
 
-OPTIONS_TYPES: Final = {"write": "store_true"}
+OPTIONS_TYPES: Final = {"write": "store_true", "exclude": "store"}
 
 
 def _get_toml_file() -> Optional[Dict[str, Any]]:
@@ -35,6 +35,8 @@ def _parse_toml_option(opt: str, value: Any) -> List[str]:
         if value is True:
             return [f"--{opt}"]
         return []
+    if action == "store":
+        return [f"--{opt}", value]
     return []  # pragma: no cover
 
 

--- a/pydocstringformatter/configuration/validators.py
+++ b/pydocstringformatter/configuration/validators.py
@@ -1,0 +1,14 @@
+from typing import Callable, Dict, Final, List, Union
+
+
+def _comma_separated_list_validator(value: Union[str, List[str]]) -> List[str]:
+    """Validate a comma separated list."""
+    if isinstance(value, list):
+        return value
+    return value.split(",")
+
+
+ValidatedTypes = List[str]
+VALIDATORS: Final[Dict[str, Callable[[str], ValidatedTypes]]] = {
+    "csv": _comma_separated_list_validator
+}

--- a/pydocstringformatter/run.py
+++ b/pydocstringformatter/run.py
@@ -29,7 +29,7 @@ class _Run:
 
     def _check_files(self, arguments: List[str]) -> None:
         """Find all files and perform the formatting."""
-        filepaths = utils._find_python_files(arguments)
+        filepaths = utils._find_python_files(arguments, self.config.exclude)
         self._format_files(filepaths)
 
     def _format_file(self, filename: Path) -> bool:

--- a/pydocstringformatter/utils/find_python_file.py
+++ b/pydocstringformatter/utils/find_python_file.py
@@ -1,6 +1,7 @@
+import glob
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Set
 
 
 def _is_python_file(filename: str) -> bool:
@@ -8,9 +9,15 @@ def _is_python_file(filename: str) -> bool:
     return filename.endswith(".py")
 
 
-def _find_python_files(filenames: List[str], recursive: bool = True) -> List[Path]:
+def _find_python_files(
+    filenames: List[str], exclude: List[str], recursive: bool = True
+) -> List[Path]:
     """Find all python files for a list of potential file and directory names."""
     pathnames: List[Path] = []
+
+    to_exclude: Set[str] = set()
+    for exclude_glob in exclude:
+        to_exclude.update(set(glob.iglob(exclude_glob, recursive=recursive)))
 
     for name in filenames:
         if os.path.isdir(name):
@@ -20,6 +27,7 @@ def _find_python_files(filenames: List[str], recursive: bool = True) -> List[Pat
                         Path(os.path.abspath(root)) / child
                         for child in children
                         if _is_python_file(child)
+                        and str(Path(root) / child) not in to_exclude
                     ]
             else:
                 pathnames += [

--- a/tests/data/config/exclude_match/pyproject.toml
+++ b/tests/data/config/exclude_match/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pydocstringformatter]
+exclude = "**/test_package/**"

--- a/tests/data/config/exclude_match/test_package/incorrect_docstring.py
+++ b/tests/data/config/exclude_match/test_package/incorrect_docstring.py
@@ -1,0 +1,2 @@
+"""
+A docstring"""

--- a/tests/data/config/exclude_match_csv/pyproject.toml
+++ b/tests/data/config/exclude_match_csv/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pydocstringformatter]
+exclude = "**/test_packages/**,**/test_package/**"

--- a/tests/data/config/exclude_match_csv/test_package/incorrect_docstring.py
+++ b/tests/data/config/exclude_match_csv/test_package/incorrect_docstring.py
@@ -1,0 +1,2 @@
+"""
+A docstring"""

--- a/tests/data/config/exclude_match_csv_list/pyproject.toml
+++ b/tests/data/config/exclude_match_csv_list/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pydocstringformatter]
+exclude = ["**/test_package/**", "**/test_packages/**"]

--- a/tests/data/config/exclude_match_csv_list/test_package/incorrect_docstring.py
+++ b/tests/data/config/exclude_match_csv_list/test_package/incorrect_docstring.py
@@ -1,0 +1,2 @@
+"""
+A docstring"""

--- a/tests/data/config/exclude_match_inner/pyproject.toml
+++ b/tests/data/config/exclude_match_inner/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pydocstringformatter]
+exclude = "**/inner_dir/**"

--- a/tests/data/config/exclude_match_inner/test_package/inner_dir/incorrect_docstring.py
+++ b/tests/data/config/exclude_match_inner/test_package/inner_dir/incorrect_docstring.py
@@ -1,0 +1,2 @@
+"""
+A docstring"""

--- a/tests/data/config/exclude_non_match/pyproject.toml
+++ b/tests/data/config/exclude_non_match/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pydocstringformatter]
+exclude = "**test_packages**"

--- a/tests/data/config/exclude_non_match/test_package/incorrect_docstring.py
+++ b/tests/data/config/exclude_non_match/test_package/incorrect_docstring.py
@@ -1,0 +1,2 @@
+"""
+A docstring"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -138,3 +138,69 @@ def test_version_argument(capsys: pytest.CaptureFixture[str]) -> None:
     output = capsys.readouterr()
     assert output.out == pydocstringformatter.__version__ + "\n"
     assert not output.err
+
+
+class TestExcludeOption:
+    """Tests for the --exclude option"""
+
+    @staticmethod
+    def test_exclude_non_match(
+        capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test when there is no match with the pattern."""
+        monkeypatch.chdir(CONFIG_DATA / "exclude_non_match")
+        pydocstringformatter.run_docstring_formatter(["test_package"])
+        output = capsys.readouterr()
+        assert output.out.endswith(
+            '''
+@@ -1,3 +1,2 @@
+-"""
+-A docstring"""
++"""A docstring."""
+ '''
+        )
+        assert not output.err
+
+    @staticmethod
+    def test_exclude_match(
+        capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test when the directory matches the pattern."""
+        monkeypatch.chdir(CONFIG_DATA / "exclude_match")
+        pydocstringformatter.run_docstring_formatter(["test_package"])
+        output = capsys.readouterr()
+        assert output.out == "Nothing to do! All docstrings are correct 🎉\n"
+        assert not output.err
+
+    @staticmethod
+    def test_exclude_match_inner_directory(
+        capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test when the inner directory matches the pattern."""
+        monkeypatch.chdir(CONFIG_DATA / "exclude_match_inner")
+        pydocstringformatter.run_docstring_formatter(["test_package"])
+        output = capsys.readouterr()
+        assert output.out == "Nothing to do! All docstrings are correct 🎉\n"
+        assert not output.err
+
+    @staticmethod
+    def test_exclude_csv_string(
+        capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test when there is a match with a string in a csv string."""
+        monkeypatch.chdir(CONFIG_DATA / "exclude_match_csv")
+        pydocstringformatter.run_docstring_formatter(["test_package"])
+        output = capsys.readouterr()
+        assert output.out == "Nothing to do! All docstrings are correct 🎉\n"
+        assert not output.err
+
+    @staticmethod
+    def test_exclude_csv_list(
+        capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test when there is a match with a string in a list of strings."""
+        monkeypatch.chdir(CONFIG_DATA / "exclude_match_csv_list")
+        pydocstringformatter.run_docstring_formatter(["test_package"])
+        output = capsys.readouterr()
+        assert output.out == "Nothing to do! All docstrings are correct 🎉\n"
+        assert not output.err

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ class TestPythonFileFinder:
     @staticmethod
     def test_underscores_files() -> None:
         """Test that we can find files with leading underscores"""
-        pathnames = _find_python_files([str(UTILS_DATA / "find_underscore_files")])
+        pathnames = _find_python_files([str(UTILS_DATA / "find_underscore_files")], [])
         expected_paths = [
             UTILS_DATA / "find_underscore_files" / "file_one.py",
             UTILS_DATA / "find_underscore_files" / "_file_two.py",
@@ -31,7 +31,7 @@ class TestPythonFileFinder:
     def test_recursive_files() -> None:
         """Test that we can find files recursively"""
         pathnames = _find_python_files(
-            [str(UTILS_DATA / "find_recursive_files")], recursive=True
+            [str(UTILS_DATA / "find_recursive_files")], [], recursive=True
         )
         expected_paths = [
             UTILS_DATA / "find_recursive_files" / "file_one.py",
@@ -50,7 +50,7 @@ class TestPythonFileFinder:
     @staticmethod
     def test_recursive_files_standard() -> None:
         """Test that we can find files recursively even if argument is not supplied"""
-        pathnames = _find_python_files([str(UTILS_DATA / "find_recursive_files")])
+        pathnames = _find_python_files([str(UTILS_DATA / "find_recursive_files")], [])
         expected_paths = [
             UTILS_DATA / "find_recursive_files" / "file_one.py",
             UTILS_DATA
@@ -69,7 +69,7 @@ class TestPythonFileFinder:
     def test_ignore_recursive_files() -> None:
         """Test that we ignore inner directories if recusrive is False"""
         pathnames = _find_python_files(
-            [str(UTILS_DATA / "find_recursive_files")], recursive=False
+            [str(UTILS_DATA / "find_recursive_files")], [], recursive=False
         )
         expected_paths = [UTILS_DATA / "find_recursive_files" / "file_one.py"]
         assert sorted(expected_paths) == pathnames
@@ -77,7 +77,9 @@ class TestPythonFileFinder:
     @staticmethod
     def test_ignore_non_python_file() -> None:
         """Test that we ignore a non Python file"""
-        pathnames = _find_python_files([str(UTILS_DATA / "find_nothing" / "README.md")])
+        pathnames = _find_python_files(
+            [str(UTILS_DATA / "find_nothing" / "README.md")], []
+        )
         assert not pathnames
 
 


### PR DESCRIPTION
Closes #1 

`glob` is apparently pretty bad for ignoring stuff and is only used to capture things. (include vs. exclude).

However, for now I think this will be fine. I'm not sure about the tests and whether this catches everything, but at least we can get feedback if this works now!