### PR TITLE
Use ``(de)activate_option`` properties outside of tests

### DIFF
--- a/pydocstringformatter/configuration/formatter_options.py
+++ b/pydocstringformatter/configuration/formatter_options.py
@@ -13,9 +13,9 @@ def _load_formatters_default_option(
     arguments: List[str] = []
     for formatter in formatters:
         if formatter.optional:
-            arguments.append(f"--no-{formatter.name}")
+            arguments.append(formatter.deactivate_option)
         elif not formatter.optional:
-            arguments.append(f"--{formatter.name}")
+            arguments.append(formatter.activate_option)
 
     parser.parse_known_args(arguments, namespace)
 
@@ -28,11 +28,14 @@ def _register_arguments_formatters(
         name = formatter.name
         help_text = f"ctivate the {name} formatter"
         parser.add_argument(
-            f"--{name}",
+            formatter.activate_option,
             action="store_true",
             dest=name,
             help=f"A{help_text} : {formatter.__doc__}",
         )
         parser.add_argument(
-            f"--no-{name}", action="store_false", dest=name, help=f"Dea{help_text}"
+            formatter.deactivate_option,
+            action="store_false",
+            dest=name,
+            help=f"Dea{help_text}",
         )


### PR DESCRIPTION
Follow up to #32, which uses the new properties throughout the codebase.