### PR TITLE
Special case Sphinx-style titles for ``FinalPeriodFormatter``

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ multi-line docstring
 
 **PEP 257: _The closing quotes are on the same line as the opening quotes_**
 
-For consistency this rule also gets applied to multi-line docstrings
+For consistency this rule also gets applied to multi-line docstrings.
 
 ```python
 # Bad
@@ -110,6 +110,9 @@ multi-line docstring
 **PEP 257: _The docstring is a phrase ending in a period & Multi-line docstrings consist
 of a summary line just like a one-line docstring_**
 
+When the second line is one recurring character we consider the summary line to be a
+title as used in many Sphinx documentation schemes and do not add a period.
+
 ```python
 # Bad
 """My docstring"""
@@ -127,24 +130,39 @@ My docstring
 
 My docstring
 """
+
+"""My title
+===========
+
+My docstring
+"""
 ```
 
 **PEP 257: _Multi-line docstrings consist of a summary line just like a one-line
 docstring, followed by a blank line, followed by a more elaborate description._**
+
+When the second line is one recurring character we consider the summary line to be a
+title as used in many Sphinx documentation schemes and do not add a white line.
 
 ```python
 # Bad
 """Summary. Body."""
 
 """Summary.
-   Body.
-   """
+Body.
+"""
 
 # Good
 """Summary.
 
-   Body.
-   """
+Body.
+"""
+
+"""My title
+===========
+
+My docstring
+"""
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ multi-line docstring
 of a summary line just like a one-line docstring_**
 
 Since the first line should be a phrase or summary the first character gets capitalized.
+
 When the second line is one recurring character we consider the summary line to be a
 title as used in many Sphinx documentation schemes and do not add a period.
 

--- a/pydocstringformatter/formatting/formatter.py
+++ b/pydocstringformatter/formatting/formatter.py
@@ -44,7 +44,7 @@ class FinalPeriodFormatter(StringFormatter):
 
     name = "final-period"
 
-    def _treat_string(self, tokeninfo: tokenize.TokenInfo, indent_length: int) -> str:
+    def _treat_string(self, tokeninfo: tokenize.TokenInfo, _: int) -> str:
         """Add a period to the end of single-line docstrings and summaries."""
         # Handle single line docstrings
         if not tokeninfo.string.count("\n"):

--- a/pydocstringformatter/formatting/formatter.py
+++ b/pydocstringformatter/formatting/formatter.py
@@ -44,7 +44,7 @@ class FinalPeriodFormatter(StringFormatter):
 
     name = "final-period"
 
-    def _treat_string(self, tokeninfo: tokenize.TokenInfo, _: int) -> str:
+    def _treat_string(self, tokeninfo: tokenize.TokenInfo, indent_length: int) -> str:
         """Add a period to the end of single-line docstrings and summaries."""
         # Handle single line docstrings
         if not tokeninfo.string.count("\n"):
@@ -52,15 +52,16 @@ class FinalPeriodFormatter(StringFormatter):
                 return tokeninfo.string[:-3] + "." + tokeninfo.string[-3:]
         # Handle multi-line docstrings
         else:
-            first_linebreak = tokeninfo.string.index("\n")
-            # If first linebreak is followed by another we're dealing with a summary
-            if tokeninfo.string[tokeninfo.string.index("\n") + 1] == "\n":
-                if tokeninfo.string[first_linebreak - 1] != ".":
-                    return (
-                        tokeninfo.string[:first_linebreak]
-                        + "."
-                        + tokeninfo.string[first_linebreak:]
-                    )
+            lines = tokeninfo.string.splitlines()
+            # If second line is one recurring character we're dealing with a rst title
+            if (stripped := lines[1].lstrip()) and stripped.count(stripped[0]) == len(
+                stripped
+            ):
+                return tokeninfo.string
+            # If second line is empty we're dealing with a summary
+            if lines[1] == "":
+                if lines[0][-1] != ".":
+                    return lines[0] + ".\n" + "\n".join(lines[1:])
             # TODO(#26): Handle multi-line docstrings that do not have a summary
             # This is obviously dependent on whether 'pydocstringformatter' will
             # start enforcing summaries :)

--- a/tests/data/format/final_period/function_title_docstrings.py
+++ b/tests/data/format/final_period/function_title_docstrings.py
@@ -1,0 +1,42 @@
+def func():
+    def inner_func():
+        """Summary
+        ==========
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        ----------
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        ^^^^^^^^^^
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        **********
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        ^^^^^^^^^^
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        aaaaaaaaaa
+
+        docstring
+        """

--- a/tests/data/format/final_period/function_title_docstrings.py.out
+++ b/tests/data/format/final_period/function_title_docstrings.py.out
@@ -1,0 +1,42 @@
+def func():
+    def inner_func():
+        """Summary
+        ==========
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        ----------
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        ^^^^^^^^^^
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        **********
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        ^^^^^^^^^^
+
+        docstring
+        """
+
+    def inner_func():
+        """Summary
+        aaaaaaaaaa
+
+        docstring
+        """


### PR DESCRIPTION
First step towards #36.

This already works with the current code, but now when we change anything in `FinalPeriodFormatter` we make sure that this keeps working.
Second step would be to recognise Sphinx-style titles in ``BeginningQuotesFormatter``.