### PR TITLE
Handle docstrings in single quoted strings correctly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
     rev: v0.931
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports]
+        args: [--ignore-missing-imports, --config-file=pyproject.toml]
         exclude: *test-data
         additional_dependencies: [pytest-stub==1.1.0]
   - repo: https://github.com/DanielNoord/pydocstringformatter

--- a/pydocstringformatter/__init__.py
+++ b/pydocstringformatter/__init__.py
@@ -8,7 +8,7 @@ from pydocstringformatter.utils.exceptions import (
     PydocstringFormatterError,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.4.0+dev"
 
 
 def run_docstring_formatter(argv: Union[List[str], None] = None) -> None:

--- a/pydocstringformatter/formatting/base.py
+++ b/pydocstringformatter/formatting/base.py
@@ -1,5 +1,7 @@
 import abc
+import re
 import tokenize
+from typing import Literal
 
 
 class Formatter:
@@ -43,6 +45,45 @@ class StringFormatter(Formatter):
         return tokenize.TokenInfo(
             tokeninfo.type,
             self._treat_string(tokeninfo, tokeninfo.start[1]),
+            tokeninfo.start,
+            tokeninfo.end,
+            tokeninfo.line,
+        )
+
+
+class StringAndQuotesFormatter(Formatter):
+    """Base class for string formatter that needs access to the quotes."""
+
+    quotes_regex = re.compile(r"""['"]{1,3}""")
+    """Pattern to match against opening quotes."""
+
+    @abc.abstractmethod
+    def _treat_string(
+        self,
+        tokeninfo: tokenize.TokenInfo,
+        indent_length: int,
+        quotes: str,
+        quotes_length: Literal[1, 3],
+    ) -> str:
+        """Return a modified string."""
+
+    def treat_token(self, tokeninfo: tokenize.TokenInfo) -> tokenize.TokenInfo:
+        # Get the quotes used for this docstring
+        match = re.match(self.quotes_regex, tokeninfo.string)
+        assert match
+        quotes = match.group()
+
+        quotes_length = len(quotes)
+        assert quotes_length in {1, 3}
+
+        return tokenize.TokenInfo(
+            tokeninfo.type,
+            self._treat_string(
+                tokeninfo,
+                tokeninfo.start[1],
+                quotes,
+                quotes_length,  # type: ignore[arg-type]
+            ),
             tokeninfo.start,
             tokeninfo.end,
             tokeninfo.line,

--- a/tests/data/format/capitalization_first_letter/single_quote_docstring.py
+++ b/tests/data/format/capitalization_first_letter/single_quote_docstring.py
@@ -1,0 +1,2 @@
+def func():
+    "a docstring."

--- a/tests/data/format/capitalization_first_letter/single_quote_docstring.py.out
+++ b/tests/data/format/capitalization_first_letter/single_quote_docstring.py.out
@@ -1,0 +1,2 @@
+def func():
+    "A docstring."

--- a/tests/data/format/final_period/single_quote_docstring.py
+++ b/tests/data/format/final_period/single_quote_docstring.py
@@ -1,0 +1,2 @@
+def func():
+    "A docstring"

--- a/tests/data/format/final_period/single_quote_docstring.py.out
+++ b/tests/data/format/final_period/single_quote_docstring.py.out
@@ -1,0 +1,2 @@
+def func():
+    "A docstring."

--- a/tests/data/format/whitespace_stripper/single_quote_docstring.py
+++ b/tests/data/format/whitespace_stripper/single_quote_docstring.py
@@ -1,0 +1,2 @@
+def func():
+    " A docstring. "

--- a/tests/data/format/whitespace_stripper/single_quote_docstring.py.out
+++ b/tests/data/format/whitespace_stripper/single_quote_docstring.py.out
@@ -1,0 +1,2 @@
+def func():
+    "A docstring."


### PR DESCRIPTION
Fixes a part of #45.

I'd like to add the quotes formatter as well to `0.4.0` so we can also fix the underlying issue when running the formatter over `pylint` 😄 