### PR TITLE
Add ':' and ';' to allowed punctuation

### DIFF
--- a/pydocstringformatter/formatting/formatter.py
+++ b/pydocstringformatter/formatting/formatter.py
@@ -65,7 +65,7 @@ class FinalPeriodFormatter(StringAndQuotesFormatter):
     """Add a period to the end of single line docstrings and summaries."""
 
     name = "final-period"
-    END_OF_SENTENCE_PUNCTUATION = {".", "?", "!", "‽"}
+    END_OF_SENTENCE_PUNCTUATION = {".", "?", "!", "‽", ":", ";"}
 
     def _treat_string(
         self,

--- a/tests/data/format/final_period/exotic_line_ending.py
+++ b/tests/data/format/final_period/exotic_line_ending.py
@@ -1,0 +1,11 @@
+def function():
+    """Check the name of first argument, expect:
+
+      *'self' for a regular method
+      *'cls' for a class method or a metaclass regular method"""
+
+def function():
+    """This has peculiar line ending;
+
+    but it should not matter.
+                """

--- a/tests/data/format/final_period/exotic_line_ending.py.out
+++ b/tests/data/format/final_period/exotic_line_ending.py.out
@@ -1,0 +1,13 @@
+def function():
+    """Check the name of first argument, expect:
+
+      *'self' for a regular method
+      *'cls' for a class method or a metaclass regular method
+    """
+
+def function():
+    """This has peculiar line ending;
+
+    but it should not matter.
+
+    """


### PR DESCRIPTION
This permit to stay sane for this:
```diff
-        """Check the name of first argument, expect:
+        """Check the name of first argument, expect:.
 
         * 'self' for a regular method
         * 'cls' for a class method or a metaclass regular method (actually
```