### PR TITLE
Add a usage page to the documentation

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,40 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  docs-build:
+    name: Docs / Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2.3.2
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: pip install -U -r requirements-test.txt
+      - name: Make docs
+        run: |
+          cd docs
+          make html
+      - name: Compare the diff
+        run: |
+          git diff > DIFF
+          if [ -s DIFF ]; then
+            echo "Documentation is not up to date."
+            echo "Please perform the following commands locally and then re-commit."
+            echo "pip install -e ."
+            echo "cd docs"
+            echo "make html"
+            exit 1
+          else
+            echo "Documentation is up to date."
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,9 +50,10 @@ repos:
     rev: v0.931
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports, --config-file=pyproject.toml]
+        args: [--config-file=pyproject.toml]
         exclude: *test-data
-        additional_dependencies: [pytest-stub==1.1.0]
+        additional_dependencies:
+          [pytest-stub==1.1.0, types-docutils~=0.17.5, sphinx~=4.4]
   - repo: https://github.com/DanielNoord/pydocstringformatter
     rev: v0.2.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ pip install pydocstringformatter
 
 ## Usage
 
+[`Click here`](https://pydocstringformatter.readthedocs.io/en/latest/usage.html) for a
+full Usage overview.
+
 ```shell
 usage: pydocstringformatter [-h] [-w] [--exclude EXCLUDE] [-v] [files ...]
 

--- a/docs/_ext/link_fixer.py
+++ b/docs/_ext/link_fixer.py
@@ -1,0 +1,63 @@
+import re
+from typing import Any, Dict
+
+from docutils import nodes
+from sphinx import addnodes, application
+from sphinx.transforms import SphinxTransform
+
+DOCUMENTATION_LINK = "https://pydocstringformatter.readthedocs.io/en/latest/"
+
+
+class LinkTransformer(SphinxTransform):
+    """Transformer to make all internal links actually internal.
+
+    For example:
+    Transforms https://pydocstringformatter.readthedocs.io/en/latest/usage.html
+    into a link to docs/usage.rst.
+    """
+
+    # Set priority very low so that we run after everything else has been done
+    default_priority = 1000
+
+    docs_regex = re.compile(r".*[/\\]docs[/\\]")
+
+    def apply(self, **_: Dict[str, Any]) -> None:
+        """Apply the transformation."""
+        for node in self.document.traverse(nodes.reference):
+            if (
+                "refuri" in node
+                and node["refuri"].startswith(DOCUMENTATION_LINK)
+                # Don't 'fix' the ReadTheDocs badge
+                and not node["refuri"].endswith("?badge=latest")
+            ):
+                # Get the ref link
+                link = node["refuri"].replace(DOCUMENTATION_LINK, "")
+                link = link.replace(".html", ".rst")
+
+                # Get the source link
+                source_link = self.document["source"]
+                source_link = re.sub(self.docs_regex, "", source_link)
+                source_link = source_link.replace(".rst", "")
+
+                # Create pending xref
+                ref = addnodes.pending_xref(
+                    refdoc=source_link,
+                    reftype="myst",
+                    reftarget=link,
+                    refexplicit=True,
+                    refdomain=True,
+                    refwarn=True,
+                )
+
+                # Make inline and add text for link
+                inline = nodes.inline(classes=["xref", "myst"])
+                inline += node.children[0]
+                ref += inline
+
+                # Replace previous link
+                node.parent.replace(node, ref)
+
+
+def setup(app: application.Sphinx) -> None:
+    """Required function to register the Sphinx extension."""
+    app.add_transform(LinkTransformer)

--- a/docs/_ext/usage_page.py
+++ b/docs/_ext/usage_page.py
@@ -1,0 +1,36 @@
+import subprocess
+
+from sphinx import application
+
+
+def write_usage_page() -> None:
+    """Write docs/usage.rst."""
+
+    # Get the help message
+    with subprocess.Popen(
+        ["pydocstringformatter", "-h"], stdout=subprocess.PIPE
+    ) as proc:
+        assert proc.stdout
+        out = proc.stdout.readlines()
+
+    # Add correct indentation for the code block
+    help_message = "    ".join(i.decode("utf-8") for i in out)
+    # Remove indentation from completely empty lines
+    help_message = help_message.replace("    \n", "\n")
+
+    with open("usage.rst", mode="w", encoding="utf-8") as file:
+        file.write(
+            f"""Usage
+=====
+
+Current usage of ``pydocstringformatter``:
+
+.. code-block:: shell
+
+    {help_message}"""
+        )
+
+
+def setup(_: application.Sphinx) -> None:
+    """Required function to register the Sphinx extension."""
+    write_usage_page()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ release = pydocstringformatter.__version__
 
 # -- General configuration ---------------------------------------------------
 
-extensions = ["myst_parser"]
+extensions = ["myst_parser", "docs._ext.usage_page", "docs._ext.link_fixer"]
 myst_heading_anchors = 2
 source_suffix = [".rst", ".md"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,2 +1,7 @@
+.. toctree::
+   :hidden:
+
+   usage
+
 .. include:: ../README.md
    :parser: myst_parser.sphinx_

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -1,3 +1,4 @@
 -e .
 myst-parser~=0.16
 sphinx~=4.4
+types-docutils~=0.17.5

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,69 @@
+Usage
+=====
+
+Current usage of ``pydocstringformatter``:
+
+.. code-block:: shell
+
+    usage: pydocstringformatter [-h] [-w] [--quiet] [-v] [--exclude EXCLUDE]
+                                [--split-summary-body] [--no-split-summary-body]
+                                [--strip-whitespaces] [--no-strip-whitespaces]
+                                [--beginning-quotes] [--no-beginning-quotes]
+                                [--closing-quotes] [--no-closing-quotes]
+                                [--capitalize-first-letter]
+                                [--no-capitalize-first-letter] [--final-period]
+                                [--no-final-period] [--quotes-type]
+                                [--no-quotes-type]
+                                [files ...]
+
+    positional arguments:
+      files                 The directory or files to format.
+
+    options:
+      -h, --help            show this help message and exit
+      -w, --write           Write the changes to file instead of printing the
+                            diffs to stdout.
+      --quiet               Do not print any logging or status messages to stdout.
+      -v, --version         Show version number and exit.
+
+    configuration:
+      --exclude EXCLUDE     A comma separated list of glob patterns of file path
+                            names not to be formatted.
+
+    default formatters:
+      these formatters are turned on by default
+
+      --strip-whitespaces   Activate the strip-whitespaces formatter : Strip 1)
+                            docstring start, 2) docstring end and 3) end of line.
+      --no-strip-whitespaces
+                            Deactivate the strip-whitespaces formatter.
+      --beginning-quotes    Activate the beginning-quotes formatter : Fix the
+                            position of the opening quotes.
+      --no-beginning-quotes
+                            Deactivate the beginning-quotes formatter.
+      --closing-quotes      Activate the closing-quotes formatter : Fix the
+                            position of the closing quotes.
+      --no-closing-quotes   Deactivate the closing-quotes formatter.
+      --capitalize-first-letter
+                            Activate the capitalize-first-letter formatter :
+                            Capitalize the first letter of the docstring if
+                            appropriate.
+      --no-capitalize-first-letter
+                            Deactivate the capitalize-first-letter formatter.
+      --final-period        Activate the final-period formatter : Add a period to
+                            the end of single line docstrings and summaries.
+      --no-final-period     Deactivate the final-period formatter.
+      --quotes-type         Activate the quotes-type formatter : Change all
+                            opening and closing quotes to be triple quotes.
+      --no-quotes-type      Deactivate the quotes-type formatter.
+
+    optional formatters:
+      these formatters are turned off by default
+
+      --split-summary-body  Activate the split-summary-body formatter : Split the
+                            summary and body of a docstring based on a period in
+                            between them. This formatter is currently optional as
+                            its considered somwehat opinionated and might require
+                            major refactoring for existing projects.
+      --no-split-summary-body
+                            Deactivate the split-summary-body formatter.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,5 +6,4 @@ pytest==6.2.5
 pytest-cov==3.0.0
 
 # Requirements for docs building
-myst-parser~=0.16
-sphinx~=4.4
+-r docs/requirements-doc.txt


### PR DESCRIPTION
Let's see how this works.

Edit: Left to do:
- Make sure the documentation builds within the `pre-commit`. Current challenge is forcing `pre-commit` to install `-e .` before running the `docs` makefile. That is necessary to build the most recent version of the documentation.