### PR TITLE
Add a newline to the end of the diff output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v4.1.0
     hooks:
       - id: trailing-whitespace
-        exclude: "tests/data/format/whitespace_stripper|tests/data/format/quotes_type"
+        exclude: "tests/data/format/whitespace_stripper|tests/data/format/quotes_type|tests/test_config.py"
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-toml
@@ -39,6 +39,7 @@ repos:
     hooks:
       - id: flake8
         exclude: *test-data
+        args: ["--ignore=W293,W503"]
         additional_dependencies: [flake8-typing-imports==1.10.1]
   - repo: https://github.com/pycqa/pylint
     rev: v2.12.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: flake8
         exclude: *test-data
-        args: ["--ignore=W293,W503"]
+        args: ["--ignore=W293,W503,E203"]
         additional_dependencies: [flake8-typing-imports==1.10.1]
   - repo: https://github.com/pycqa/pylint
     rev: v2.12.2

--- a/pydocstringformatter/utils/file_diference.py
+++ b/pydocstringformatter/utils/file_diference.py
@@ -3,12 +3,15 @@ import difflib
 
 def _generate_diff(old: str, new: str, filename: str) -> str:
     """Generate a printable diff for two strings of sourcecode."""
-    return "\n".join(
-        difflib.unified_diff(
-            old.split("\n"),
-            new.split("\n"),
-            fromfile=filename,
-            tofile=filename,
-            lineterm="",
+    return (
+        "\n".join(
+            difflib.unified_diff(
+                old.split("\n"),
+                new.split("\n"),
+                fromfile=filename,
+                tofile=filename,
+                lineterm="",
+            )
         )
+        + "\n"
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+# pylint: disable=trailing-whitespace
+
 import os
 from pathlib import Path
 
@@ -23,7 +25,8 @@ def test_no_toml(
 -"""
 -A docstring"""
 +"""A docstring."""
- '''
+ 
+'''
     )
     assert not output.err
 
@@ -52,7 +55,8 @@ def test_valid_toml_two(
 -"""
 -A docstring"""
 +"""A docstring."""
- '''
+ 
+'''
     )
     assert not output.err
 
@@ -84,7 +88,8 @@ def test_no_write_argument(capsys: pytest.CaptureFixture[str], test_file: str) -
 @@ -1,2 +1,3 @@
  """A multi-line
 -docstring."""
-+docstring.\n+"""'''
++docstring.\n+"""
+'''
     )
     assert not output.err
 
@@ -157,7 +162,8 @@ class TestExcludeOption:
 -"""
 -A docstring"""
 +"""A docstring."""
- '''
+ 
+'''
         )
         assert not output.err
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -84,7 +84,8 @@ def test_sys_agv_as_arguments(
  """A multi-line
 -docstring."""
 +docstring.
-+"""'''
++"""
+'''
     )
     assert not output.err
 


### PR DESCRIPTION
This is necessary for the primer and doesn't matter too much in normal use.