### PR TITLE
Make ``SplitSummaryAndDocstringFormatter`` non-optional

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,8 +9,8 @@ Current usage of ``pydocstringformatter``:
                                 [--exit-code]
                                 [--max-summary-lines MAX_SUMMARY_LINES]
                                 [--summary-quotes-same-line]
-                                [--split-summary-body  --no-split-summary-body]
                                 [--strip-whitespaces  --no-strip-whitespaces]
+                                [--split-summary-body  --no-split-summary-body]
                                 [--linewrap-full-docstring  --no-linewrap-full-docstring]
                                 [--beginning-quotes  --no-beginning-quotes]
                                 [--closing-quotes  --no-closing-quotes]
@@ -50,6 +50,14 @@ Current usage of ``pydocstringformatter``:
                             Activate or deactivate strip-whitespaces: Strip 1)
                             docstring start, 2) docstring end and 3) end of line.
                             (default: True)
+      --split-summary-body, --no-split-summary-body
+                            Activate or deactivate split-summary-body: Split the
+                            summary and body of a docstring based on a period and
+                            max length. The maximum length of a summary can be set
+                            with the --max-summary-lines option. This formatter is
+                            currently optional as its considered somwehat
+                            opinionated and might require major refactoring for
+                            existing projects. (default: True)
       --beginning-quotes, --no-beginning-quotes
                             Activate or deactivate beginning-quotes: Fix the
                             position of the opening quotes. (default: True)
@@ -72,14 +80,6 @@ Current usage of ``pydocstringformatter``:
     optional formatters:
       these formatters are turned off by default
 
-      --split-summary-body, --no-split-summary-body
-                            Activate or deactivate split-summary-body: Split the
-                            summary and body of a docstring based on a period and
-                            max length. The maximum length of a summary can be set
-                            with the --max-summary-lines option. This formatter is
-                            currently optional as its considered somwehat
-                            opinionated and might require major refactoring for
-                            existing projects. (default: False)
       --linewrap-full-docstring, --no-linewrap-full-docstring
                             Activate or deactivate linewrap-full-docstring:
                             Linewrap the docstring by the pre-defined line length.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -54,10 +54,7 @@ Current usage of ``pydocstringformatter``:
                             Activate or deactivate split-summary-body: Split the
                             summary and body of a docstring based on a period and
                             max length. The maximum length of a summary can be set
-                            with the --max-summary-lines option. This formatter is
-                            currently optional as its considered somwehat
-                            opinionated and might require major refactoring for
-                            existing projects. (default: True)
+                            with the --max-summary-lines option. (default: True)
       --beginning-quotes, --no-beginning-quotes
                             Activate or deactivate beginning-quotes: Fix the
                             position of the opening quotes. (default: True)

--- a/pydocstringformatter/formatting/__init__.py
+++ b/pydocstringformatter/formatting/__init__.py
@@ -21,8 +21,8 @@ from pydocstringformatter.formatting.formatter import (
 #   Determine if multi-line or single line and position quotes accordingly
 #   String manipulation in which being multi-line or single line matters
 FORMATTERS: list[Formatter] = [
-    SplitSummaryAndDocstringFormatter(),
     StripWhitespacesFormatter(),
+    SplitSummaryAndDocstringFormatter(),
     LineWrapperFormatter(),
     BeginningQuotesFormatter(),
     ClosingQuotesFormatter(),

--- a/pydocstringformatter/formatting/_utils.py
+++ b/pydocstringformatter/formatting/_utils.py
@@ -1,0 +1,5 @@
+def is_rst_title(summary: str) -> bool:
+    """Check if the second line of a summary is one recurring character."""
+    # If second line is one recurring character we're dealing with a rst title
+    last_line = summary.splitlines()[-1].lstrip()
+    return last_line.count(last_line[0]) == len(last_line)

--- a/pydocstringformatter/formatting/formatter.py
+++ b/pydocstringformatter/formatting/formatter.py
@@ -3,6 +3,7 @@ import textwrap
 import tokenize
 from typing import Literal
 
+from pydocstringformatter.formatting import _utils
 from pydocstringformatter.formatting.base import (
     StringAndQuotesFormatter,
     StringFormatter,
@@ -139,9 +140,7 @@ class FinalPeriodFormatter(SummaryFormatter):
         if summary[-1] in self.END_OF_SENTENCE_PUNCTUATION:
             return summary
 
-        # If second line is one recurring character we're dealing with a rst title
-        last_line = summary.splitlines()[-1].lstrip()
-        if last_line.count(last_line[0]) == len(last_line):
+        if _utils.is_rst_title(summary):
             return summary
 
         return summary + "."
@@ -180,6 +179,9 @@ class SplitSummaryAndDocstringFormatter(SummaryFormatter):
     ) -> str:
         """Split a summary and body if there is a period after the summary."""
         new_summary = None
+
+        if _utils.is_rst_title(summary):
+            return summary
 
         # Try to split on period
         if match := re.search(self.end_of_sentence_period, summary):

--- a/pydocstringformatter/formatting/formatter.py
+++ b/pydocstringformatter/formatting/formatter.py
@@ -156,8 +156,6 @@ class SplitSummaryAndDocstringFormatter(SummaryFormatter):
     """
 
     name = "split-summary-body"
-    # TODO(#68): Make this non-optional
-    optional = True
 
     end_of_sentence_period = re.compile(
         r"""
@@ -187,7 +185,7 @@ class SplitSummaryAndDocstringFormatter(SummaryFormatter):
         if match := re.search(self.end_of_sentence_period, summary):
             index = match.start()
 
-            if summary[: index - 1].count("\n") < self.config.max_summary_lines:
+            if summary[:index].count("\n") < self.config.max_summary_lines:
                 if len(summary) == index + 1:
                     new_summary = summary
 

--- a/pydocstringformatter/formatting/formatter.py
+++ b/pydocstringformatter/formatting/formatter.py
@@ -150,9 +150,6 @@ class SplitSummaryAndDocstringFormatter(SummaryFormatter):
     """Split the summary and body of a docstring based on a period and max length.
 
     The maximum length of a summary can be set with the --max-summary-lines option.
-
-    This formatter is currently optional as its considered somwehat opinionated
-    and might require major refactoring for existing projects.
     """
 
     name = "split-summary-body"

--- a/tests/data/format/beginning_quote/class_docstring.py.out
+++ b/tests/data/format/beginning_quote/class_docstring.py.out
@@ -1,23 +1,27 @@
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
         """
-        A multi-line
-        docstring.
+        A multi-line.
+
+        docstring
         """
 
 
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 

--- a/tests/data/format/beginning_quote/function_docstrings.py.out
+++ b/tests/data/format/beginning_quote/function_docstrings.py.out
@@ -7,11 +7,13 @@ def func():
 
 def func():
     """
-    A multi-line
-    docstring.
+    A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/beginning_quote/multi_line_no_push/class_docstring.py.out
+++ b/tests/data/format/beginning_quote/multi_line_no_push/class_docstring.py.out
@@ -1,22 +1,26 @@
 class MyClass:
     """
-    A multi-line
-    docstring.
+    A multi-line.
+
+    docstring
     """
 
     class InnerClass:
         """
-        A multi-line
-        docstring.
+        A multi-line.
+
+        docstring
         """
 
 
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/beginning_quote/multi_line_no_push/function_docstrings.py.out
+++ b/tests/data/format/beginning_quote/multi_line_no_push/function_docstrings.py.out
@@ -1,11 +1,13 @@
 def func():
     """
-    A multi-line
-    docstring.
+    A multi-line.
+
+    docstring
     """
 
     def inner_func():
         """
-        A multi-line
-        docstring.
+        A multi-line.
+
+        docstring
         """

--- a/tests/data/format/beginning_quote/multi_line_no_push/variable_docstring.py.out
+++ b/tests/data/format/beginning_quote/multi_line_no_push/variable_docstring.py.out
@@ -1,5 +1,6 @@
 MYVAR = 1
 """
-A multi-line
-docstring.
+A multi-line.
+
+docstring
 """

--- a/tests/data/format/beginning_quote/multi_line_push/class_docstring.py.out
+++ b/tests/data/format/beginning_quote/multi_line_push/class_docstring.py.out
@@ -1,20 +1,24 @@
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/beginning_quote/multi_line_push/function_docstrings.py.out
+++ b/tests/data/format/beginning_quote/multi_line_push/function_docstrings.py.out
@@ -1,9 +1,11 @@
 def func():
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/beginning_quote/multi_line_push/variable_docstring.py.out
+++ b/tests/data/format/beginning_quote/multi_line_push/variable_docstring.py.out
@@ -1,4 +1,5 @@
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """

--- a/tests/data/format/beginning_quote/variable_docstring.py.out
+++ b/tests/data/format/beginning_quote/variable_docstring.py.out
@@ -1,4 +1,5 @@
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """

--- a/tests/data/format/capitalization_first_letter/class_docstring.py.out
+++ b/tests/data/format/capitalization_first_letter/class_docstring.py.out
@@ -1,23 +1,27 @@
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
         """
-        A multi-line
-        docstring.
+        A multi-line.
+
+        docstring
         """
 
 
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 

--- a/tests/data/format/capitalization_first_letter/function_docstrings.py.out
+++ b/tests/data/format/capitalization_first_letter/function_docstrings.py.out
@@ -15,11 +15,13 @@ def func(named_parameter: str) -> None:
 
 def func():
     """
-    A multi-line
-    docstring.
+    A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/capitalization_first_letter/variable_docstring.py.out
+++ b/tests/data/format/capitalization_first_letter/variable_docstring.py.out
@@ -1,10 +1,12 @@
 MYVAR = 1
 """
-A multi-line
-docstring.
+A multi-line.
+
+docstring
 """
 
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """

--- a/tests/data/format/final_period/class_docstring.py.out
+++ b/tests/data/format/final_period/class_docstring.py.out
@@ -6,13 +6,15 @@ class MyClass:
 
 
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 

--- a/tests/data/format/final_period/exotic_line_ending.py.out
+++ b/tests/data/format/final_period/exotic_line_ending.py.out
@@ -9,5 +9,4 @@ def function():
     """This has peculiar line ending;
 
     but it should not matter.
-
     """

--- a/tests/data/format/final_period/function_docstrings.py.out
+++ b/tests/data/format/final_period/function_docstrings.py.out
@@ -6,13 +6,15 @@ def func()
 
 
 def func()
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     def inner_func()
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 

--- a/tests/data/format/final_period/module_docstring.py.out
+++ b/tests/data/format/final_period/module_docstring.py.out
@@ -1,7 +1,8 @@
 """Docstring."""
 
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
 """Summary.

--- a/tests/data/format/final_period/variable_docstring.py.out
+++ b/tests/data/format/final_period/variable_docstring.py.out
@@ -2,8 +2,9 @@ MYVAR = 1
 """Docstring."""
 
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
 MYVAR = 1

--- a/tests/data/format/linewrap_summary/function_docstrings.py
+++ b/tests/data/format/linewrap_summary/function_docstrings.py
@@ -1,12 +1,12 @@
 def func():
-    """A very long summary line that needs to be wrapped. A very long summary line that needs to be wrapped.
+    """A very long summary line that needs to be wrapped, A very long summary line that needs to be wrapped.
 
     A description that is not too long.
     """
 
 
 def func():
-    """A very long multi-line summary line that needs to be wrapped. A very long multi-line summary line that needs to be wrapped.
+    """A very long multi-line summary line that needs to be wrapped, A very long multi-line summary line that needs to be wrapped.
     A very long summary line that needs to be wrapped.
 
     A description that is not too long.
@@ -14,7 +14,7 @@ def func():
 
 
 def func():
-    """A multi-line summary that can be on one line.
+    """A multi-line summary that can be on one line,
     But it has a new line so it isn't.
 
     A description that is not too long.
@@ -24,4 +24,4 @@ def func():
 # Since the ending quotes will be appended on the same line this
 # exceeds the max length.
 def func():
-    """A multi-line summary that can be on one line. Something that is just too longgg."""
+    """A multi-line summary that can be on one line, Something that is just too longgg."""

--- a/tests/data/format/linewrap_summary/function_docstrings.py.out
+++ b/tests/data/format/linewrap_summary/function_docstrings.py.out
@@ -1,5 +1,5 @@
 def func():
-    """A very long summary line that needs to be wrapped. A very long summary line that
+    """A very long summary line that needs to be wrapped, A very long summary line that
     needs to be wrapped.
 
     A description that is not too long.
@@ -7,8 +7,9 @@ def func():
 
 
 def func():
-    """A very long multi-line summary line that needs to be wrapped. A very long multi-
+    """A very long multi-line summary line that needs to be wrapped, A very long multi-
     line summary line that needs to be wrapped.
+
     A very long summary line that needs to be wrapped.
 
     A description that is not too long.
@@ -16,7 +17,8 @@ def func():
 
 
 def func():
-    """A multi-line summary that can be on one line.
+    """A multi-line summary that can be on one line,.
+
     But it has a new line so it isn't.
 
     A description that is not too long.
@@ -26,6 +28,6 @@ def func():
 # Since the ending quotes will be appended on the same line this
 # exceeds the max length.
 def func():
-    """A multi-line summary that can be on one line. Something that is just too
+    """A multi-line summary that can be on one line, Something that is just too
     longgg.
     """

--- a/tests/data/format/multi_line/class_docstring.py.out
+++ b/tests/data/format/multi_line/class_docstring.py.out
@@ -1,20 +1,24 @@
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/multi_line/function_docstrings.py.out
+++ b/tests/data/format/multi_line/function_docstrings.py.out
@@ -6,43 +6,51 @@ def func():
 
 
 def func():
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 
 def func():
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 def func():
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """
 
 
 def func():
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/multi_line/module_docstring.py.out
+++ b/tests/data/format/multi_line/module_docstring.py.out
@@ -1,3 +1,4 @@
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """

--- a/tests/data/format/multi_line/variable_docstring.py.out
+++ b/tests/data/format/multi_line/variable_docstring.py.out
@@ -1,9 +1,11 @@
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """

--- a/tests/data/format/quotes_type/class_docstring.py.out
+++ b/tests/data/format/quotes_type/class_docstring.py.out
@@ -1,9 +1,11 @@
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/quotes_type/function_docstrings.py.out
+++ b/tests/data/format/quotes_type/function_docstrings.py.out
@@ -6,11 +6,13 @@ def func():
 
 
 def func():
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/quotes_type/module_docstring.py.out
+++ b/tests/data/format/quotes_type/module_docstring.py.out
@@ -1,9 +1,11 @@
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
 """My docstring.

--- a/tests/data/format/quotes_type/variable_docstring.py.out
+++ b/tests/data/format/quotes_type/variable_docstring.py.out
@@ -1,9 +1,11 @@
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """

--- a/tests/data/format/summary_splitter/class_docstring.args
+++ b/tests/data/format/summary_splitter/class_docstring.args
@@ -1,1 +1,0 @@
---split-summary-body

--- a/tests/data/format/summary_splitter/dots.args
+++ b/tests/data/format/summary_splitter/dots.args
@@ -1,2 +1,1 @@
---split-summary-body
 --max-summary-lines=2

--- a/tests/data/format/summary_splitter/ending_quotes.args
+++ b/tests/data/format/summary_splitter/ending_quotes.args
@@ -1,2 +1,1 @@
---split-summary-body
 --no-closing-quotes

--- a/tests/data/format/summary_splitter/function_docstrings.args
+++ b/tests/data/format/summary_splitter/function_docstrings.args
@@ -1,1 +1,0 @@
---split-summary-body

--- a/tests/data/format/summary_splitter/max_summary_lines/max_lines_is_1.args
+++ b/tests/data/format/summary_splitter/max_summary_lines/max_lines_is_1.args
@@ -1,2 +1,1 @@
---split-summary-body
 --max-summary-lines=1

--- a/tests/data/format/summary_splitter/max_summary_lines/max_lines_is_2.args
+++ b/tests/data/format/summary_splitter/max_summary_lines/max_lines_is_2.args
@@ -1,2 +1,1 @@
---split-summary-body
 --max-summary-lines=2

--- a/tests/data/format/summary_splitter/max_summary_lines/max_lines_is_3.args
+++ b/tests/data/format/summary_splitter/max_summary_lines/max_lines_is_3.args
@@ -1,2 +1,1 @@
---split-summary-body
 --max-summary-lines=3

--- a/tests/data/format/summary_splitter/max_summary_lines/max_lines_is_default.args
+++ b/tests/data/format/summary_splitter/max_summary_lines/max_lines_is_default.args
@@ -1,1 +1,0 @@
---split-summary-body

--- a/tests/data/format/summary_splitter/max_summary_lines/max_lines_with_dot.args
+++ b/tests/data/format/summary_splitter/max_summary_lines/max_lines_with_dot.args
@@ -1,1 +1,0 @@
---split-summary-body

--- a/tests/data/format/summary_splitter/module_docstring.args
+++ b/tests/data/format/summary_splitter/module_docstring.args
@@ -1,1 +1,0 @@
---split-summary-body

--- a/tests/data/format/summary_splitter/variable_docstring.args
+++ b/tests/data/format/summary_splitter/variable_docstring.args
@@ -1,1 +1,0 @@
---split-summary-body

--- a/tests/data/format/whitespace_stripper/class_docstring.py.out
+++ b/tests/data/format/whitespace_stripper/class_docstring.py.out
@@ -1,9 +1,11 @@
 class MyClass:
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     class InnerClass:
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/whitespace_stripper/function_docstrings.py.out
+++ b/tests/data/format/whitespace_stripper/function_docstrings.py.out
@@ -6,11 +6,13 @@ def func():
 
 
 def func():
-    """A multi-line
-    docstring.
+    """A multi-line.
+
+    docstring
     """
 
     def inner_func():
-        """A multi-line
-        docstring.
+        """A multi-line.
+
+        docstring
         """

--- a/tests/data/format/whitespace_stripper/module_docstring.py.out
+++ b/tests/data/format/whitespace_stripper/module_docstring.py.out
@@ -1,9 +1,11 @@
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
 """My docstring.

--- a/tests/data/format/whitespace_stripper/variable_docstring.py.out
+++ b/tests/data/format/whitespace_stripper/variable_docstring.py.out
@@ -1,9 +1,11 @@
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """
 
 MYVAR = 1
-"""A multi-line
-docstring.
+"""A multi-line.
+
+docstring
 """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,10 +85,13 @@ def test_no_write_argument(capsys: pytest.CaptureFixture[str], test_file: str) -
     output = capsys.readouterr()
     assert output.out.endswith(
         '''
-@@ -1,2 +1,3 @@
- """A multi-line
+@@ -1,2 +1,4 @@
+-"""A multi-line
 -docstring."""
-+docstring.\n+"""
++"""A multi-line.
++
++docstring.
++"""
 '''
     )
     assert not output.err
@@ -104,7 +107,7 @@ def test_write_argument(capsys: pytest.CaptureFixture[str], test_file: str) -> N
     pydocstringformatter.run_docstring_formatter([test_file, "-w"])
 
     with open(test_file, encoding="utf-8") as file:
-        assert "".join(file.readlines()) == '"""A multi-line\ndocstring.\n"""'
+        assert "".join(file.readlines()) == '"""A multi-line.\n\ndocstring.\n"""'
 
     output = capsys.readouterr()
     assert output.out == f"Formatted {expected_path} 📖\n"
@@ -123,7 +126,7 @@ def test_long_write_argument(
     pydocstringformatter.run_docstring_formatter([test_file, "--write"])
 
     with open(test_file, encoding="utf-8") as file:
-        assert "".join(file.readlines()) == '"""A multi-line\ndocstring.\n"""'
+        assert "".join(file.readlines()) == '"""A multi-line.\n\ndocstring.\n"""'
 
     output = capsys.readouterr()
     assert output.out == f"Formatted {expected_path} 📖\n"
@@ -217,7 +220,7 @@ class TestExcludeOption:
         pydocstringformatter.run_docstring_formatter([test_file, "-w", "--quiet"])
 
         with open(test_file, encoding="utf-8") as file:
-            assert "".join(file.readlines()) == '"""A multi-line\ndocstring.\n"""'
+            assert "".join(file.readlines()) == '"""A multi-line.\n\ndocstring.\n"""'
 
         output = capsys.readouterr()
         assert not output.out

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -86,9 +86,11 @@ def test_sys_agv_as_arguments(
     output = capsys.readouterr()
     assert output.out.endswith(
         '''
-@@ -1,2 +1,3 @@
- """A multi-line
+@@ -1,2 +1,4 @@
+-"""A multi-line
 -docstring."""
++"""A multi-line.
++
 +docstring.
 +"""
 '''
@@ -101,9 +103,9 @@ def test_output_message_nothing_done(
 ) -> None:
     """Test that we emit the correct message when nothing was done."""
     with open(test_file, "w", encoding="utf-8") as file:
-        file.write('"""A multi-line\ndocstring.\n"""')
+        file.write('"""A multi-line.\n\ndocstring.\n"""')
     with open(test_file.replace(".py", "2.py"), "w", encoding="utf-8") as file:
-        file.write('"""A multi-line\ndocstring.\n"""')
+        file.write('"""A multi-line.\n\ndocstring.\n"""')
 
     pydocstringformatter.run_docstring_formatter(
         [str(Path(test_file).parent), "--write"]
@@ -124,7 +126,7 @@ def test_output_message_one_file(
         expected_path = test_file
 
     with open(test_file.replace(".py", "2.py"), "w", encoding="utf-8") as file:
-        file.write('"""A multi-line\ndocstring.\n"""')
+        file.write('"""A multi-line.\n\ndocstring.\n"""')
 
     pydocstringformatter.run_docstring_formatter(
         [str(Path(test_file).parent), "--write"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -150,7 +150,7 @@ def test_encoding_of_console_messages(
     """
     sys.stdout.reconfigure(encoding="cp1252")  # type: ignore[attr-defined]
     with open(test_file, "w", encoding="utf-8") as file:
-        file.write('"""A multi-line\ndocstring.\n"""')
+        file.write('"""A multi-line.\n\ndocstring.\n"""')
 
     pydocstringformatter.run_docstring_formatter([test_file, "--write"])
 


### PR DESCRIPTION
Closes #68.

Best viewed commit per commit. Sadly had to update a lot of test outputs as they do not adhere to the formatting of this checker.