### PR TITLE
Max line length

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ options:
   -w, --write           Write the changes to file instead of printing the diffs to stdout.
   --quiet               Do not print any logging or status messages to stdout.
   -v, --version         Show version number and exit.
+  --max-line-length     The maximum docstring line length. Default set to 88.
 
 configuration:
   --exclude EXCLUDE     A comma separated list of glob patterns of file path names not to be formatted.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -6,9 +6,9 @@ Current usage of ``pydocstringformatter``:
 .. code-block:: shell
 
     usage: pydocstringformatter [-h] [-w] [--quiet] [-v] [--exclude EXCLUDE]
-                                [--exit-code]
-                                [--max-summary-lines MAX_SUMMARY_LINES]
+                                [--exit-code] [--max-summary-lines int]
                                 [--summary-quotes-same-line]
+                                [--max-line-length int]
                                 [--strip-whitespaces  --no-strip-whitespaces]
                                 [--split-summary-body  --no-split-summary-body]
                                 [--linewrap-full-docstring  --no-linewrap-full-docstring]
@@ -35,13 +35,15 @@ Current usage of ``pydocstringformatter``:
       --exit-code           Turn on if the program should exit with bitwise exit
                             codes. 0 = No changes, 32 = Changed files or printed
                             diff.
-      --max-summary-lines MAX_SUMMARY_LINES
+      --max-summary-lines int
                             The maximum numbers of lines a summary can span. The
                             default value is 1.
       --summary-quotes-same-line
                             Force the start of a multi-line docstring to be on the
                             same line as the opening quotes. Similar to how this
                             is enforced for single line docstrings.
+      --max-line-length int
+                            Maximum line length of docstrings.
 
     default formatters:
       these formatters are turned on by default

--- a/pydocstringformatter/configuration/arguments_manager.py
+++ b/pydocstringformatter/configuration/arguments_manager.py
@@ -96,6 +96,7 @@ class ArgumentsManager:
                 "The maximum numbers of lines a summary can span. "
                 "The default value is 1."
             ),
+            metavar="int",
         )
 
         self.configuration_group.add_argument(
@@ -106,6 +107,15 @@ class ArgumentsManager:
                 "same line as the opening quotes. Similar to how this is enforced "
                 "for single line docstrings."
             ),
+        )
+
+        self.configuration_group.add_argument(
+            "--max-line-length",
+            action="store",
+            default=88,
+            type=int,
+            help="Maximum line length of docstrings.",
+            metavar="int",
         )
 
     def parse_options(

--- a/pydocstringformatter/formatting/base.py
+++ b/pydocstringformatter/formatting/base.py
@@ -145,7 +145,7 @@ class SummaryAndDescriptionFormatter(StringAndQuotesFormatter):
         # Remove opening quotes
         summary = summary[quotes_length:]
 
-        # Prefix is the new-line + idententation for summaries that
+        # Prefix is the new-line + indentation for summaries that
         # are not on the same line as the opening quotes
         prefix = ""
         if summary.startswith("\n"):

--- a/pydocstringformatter/formatting/formatter.py
+++ b/pydocstringformatter/formatting/formatter.py
@@ -73,7 +73,7 @@ class LineWrapperFormatter(SummaryFormatter):
     ) -> str:
         """Wrap the summary of a docstring."""
 
-        line_length = 88
+        line_length = self.config.max_line_length
 
         # Without a description we need to consider the length including closing quotes
         if not description_exists:
@@ -84,7 +84,7 @@ class LineWrapperFormatter(SummaryFormatter):
             # If potential length is less than line length we need to consider ending
             # quotes as well for the line length
             if length_without_ending < line_length:
-                # We substract one more because we don't want a new line with just the
+                # We subtract one more because we don't want a new line with just the
                 # ending quotes
                 line_length -= quotes_length + 1
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,8 @@ coveralls==3.3.1
 pytest==6.2.5
 pytest-cov==3.0.0
 gitpython>=3
+pre-commit==2.19.0
+
 
 # Requirements for docs building
 -r docs/requirements-doc.txt

--- a/tests/data/format/linewrap_summary/max_line_length_50.args
+++ b/tests/data/format/linewrap_summary/max_line_length_50.args
@@ -1,0 +1,2 @@
+--linewrap-full-docstring
+--max-line-length=50

--- a/tests/data/format/linewrap_summary/max_line_length_50.py
+++ b/tests/data/format/linewrap_summary/max_line_length_50.py
@@ -1,0 +1,13 @@
+def func():
+    """A very long line that needs to be wrapped especially this sentence."""
+
+def func():
+    """Event multi line docstrings need to be wrapped.
+
+    This description is way too long. It definitely needs to be wrapped.
+    """
+
+# Regression for bug found in pylint
+# We should re-add the quotes to line length if they will never be on the first line.
+class LinesChunk:
+    """The LinesChunk object computes and store."""

--- a/tests/data/format/linewrap_summary/max_line_length_50.py.out
+++ b/tests/data/format/linewrap_summary/max_line_length_50.py.out
@@ -1,0 +1,18 @@
+def func():
+    """A very long line that needs to be wrapped
+    especially this sentence.
+    """
+
+def func():
+    """Event multi line docstrings need to be
+    wrapped.
+
+    This description is way too long. It definitely needs to be wrapped.
+    """
+
+# Regression for bug found in pylint
+# We should re-add the quotes to line length if they will never be on the first line.
+class LinesChunk:
+    """The LinesChunk object computes and
+    store.
+    """


### PR DESCRIPTION
Small update to have max-line-length as a argument.

Sorry, but didn't have time to make tests pass. Some magic happens below :stuck_out_tongue: 

Closes https://github.com/DanielNoord/pydocstringformatter/issues/90