### PR TITLE
fix: write file using existing newlines (fixes #115)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests/data/format/newlines/* -text

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,9 @@ repos:
     rev: v4.3.0
     hooks:
       - id: trailing-whitespace
-        exclude: "tests/data/format/whitespace_stripper|tests/data/format/quotes_type|tests/test_config.py"
+        exclude: "tests/data/format/whitespace_stripper|tests/data/format/quotes_type|tests/data/format/newlines|tests/test_config.py"
       - id: end-of-file-fixer
+        exclude: "tests/data/format/newlines"
       - id: check-yaml
       - id: check-toml
         exclude: &test-data "tests/data"

--- a/pydocstringformatter/run.py
+++ b/pydocstringformatter/run.py
@@ -64,6 +64,9 @@ class _Run:
                 raise utils.ParsingError(
                     f"Can't parse {os.path.relpath(filename)}. Is it valid Python code?"
                 ) from exc
+            # Record type of newlines so we can make sure to use
+            # the same later on.
+            newlines = file.newlines
 
         for index, tokeninfo in enumerate(tokens):
             new_tokeninfo = tokeninfo
@@ -85,7 +88,15 @@ class _Run:
                 filename_str = str(filename)
 
             if self.config.write:
-                with open(filename, "w", encoding="utf-8") as file:
+                if isinstance(newlines, tuple):
+                    newlines = newlines[0]
+                    print(
+                        "Found multiple newline variants in "
+                        f"{os.path.abspath(filename_str)}. "
+                        "Using variant that occurred first.",
+                        file=sys.stderr,
+                    )
+                with open(filename, "w", encoding="utf-8", newline=newlines) as file:
                     file.write(tokenize.untokenize(changed_tokens))
                     utils._print_to_console(
                         f"Formatted {filename_str} 📖\n", self.config.quiet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ enable = [
 
 [tool.pylint.BASIC]
 no-docstring-rgx = "__.*__"
+good-names = "f"
 
 [tool.pylint.TYPECHECK]
 generated-members = "argparse.Namespace"

--- a/tests/data/format/newlines/dos.py
+++ b/tests/data/format/newlines/dos.py
@@ -1,0 +1,7 @@
+var = 1
+"""A multi-line.
+docstring."""
+
+var = 1
+"""A single-line docstring.
+"""

--- a/tests/data/format/newlines/dos.py.out
+++ b/tests/data/format/newlines/dos.py.out
@@ -1,0 +1,8 @@
+var = 1
+"""A multi-line.
+
+docstring.
+"""
+
+var = 1
+"""A single-line docstring."""

--- a/tests/data/format/newlines/mac.py
+++ b/tests/data/format/newlines/mac.py
@@ -1,0 +1,1 @@
+var = 1"""A multi-line.docstring."""var = 1"""A single-line docstring."""

--- a/tests/data/format/newlines/mac.py.out
+++ b/tests/data/format/newlines/mac.py.out
@@ -1,0 +1,1 @@
+var = 1"""A multi-line.docstring."""var = 1"""A single-line docstring."""

--- a/tests/data/format/newlines/mixed.err
+++ b/tests/data/format/newlines/mixed.err
@@ -1,0 +1,1 @@
+Found multiple newline variants in {testfile}. Using variant that occurred first.

--- a/tests/data/format/newlines/mixed.py
+++ b/tests/data/format/newlines/mixed.py
@@ -1,0 +1,15 @@
+var = 1
+"""A multi-line.
+docstring."""
+
+var = 1
+"""A single-line docstring.
+"""
+
+var = 1
+"""A multi-line.
+docstring."""
+
+var = 1
+"""A single-line docstring.
+"""

--- a/tests/data/format/newlines/mixed.py.out
+++ b/tests/data/format/newlines/mixed.py.out
@@ -1,0 +1,17 @@
+var = 1
+"""A multi-line.
+
+docstring.
+"""
+
+var = 1
+"""A single-line docstring."""
+
+var = 1
+"""A multi-line.
+
+docstring.
+"""
+
+var = 1
+"""A single-line docstring."""

--- a/tests/data/format/newlines/none.args
+++ b/tests/data/format/newlines/none.args
@@ -1,0 +1,1 @@
+--linewrap-full-docstring

--- a/tests/data/format/newlines/none.py
+++ b/tests/data/format/newlines/none.py
@@ -1,0 +1,1 @@
+"""A multi-line docstring that should get split at this period. and not afterwards as it is way too long."""

--- a/tests/data/format/newlines/none.py-0d0a.out
+++ b/tests/data/format/newlines/none.py-0d0a.out
@@ -1,0 +1,4 @@
+"""A multi-line docstring that should get split at this period.
+
+and not afterwards as it is way too long.
+"""

--- a/tests/data/format/newlines/none.py.out
+++ b/tests/data/format/newlines/none.py.out
@@ -1,0 +1,4 @@
+"""A multi-line docstring that should get split at this period.
+
+and not afterwards as it is way too long.
+"""

--- a/tests/data/format/newlines/unix.py
+++ b/tests/data/format/newlines/unix.py
@@ -1,0 +1,7 @@
+var = 1
+"""A multi-line.
+docstring."""
+
+var = 1
+"""A single-line docstring.
+"""

--- a/tests/data/format/newlines/unix.py.out
+++ b/tests/data/format/newlines/unix.py.out
@@ -1,0 +1,8 @@
+var = 1
+"""A multi-line.
+
+docstring.
+"""
+
+var = 1
+"""A single-line docstring."""

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -35,23 +35,26 @@ def test_formatting(
     We create and write to a temporary file so that the original test file
     isn't overwritten and the 'py.out' file can represent an actual
     python file instead of a diff.
+
+    Everything is tested in bytes as we want to preserve the type of the
+    line endings of the original file.
     """
     # Setup
     temp_file_name = str(tmp_path / "test_file.py")
-    with open(test_file + ".out", encoding="utf-8") as expected_output:
-        expected_lines = expected_output.readlines()
+    with open(test_file, "rb") as f:
+        expected_output = f.read()
 
     # Get original lines from test file and write to temporary file
-    with open(test_file, encoding="utf-8") as original_file:
-        original_lines = original_file.readlines()
-    with open(temp_file_name, "w", encoding="utf-8") as temp_file:
-        temp_file.writelines(original_lines)
+    with open(test_file, "rb") as f:
+        original_bytes = f.read()
+    with open(temp_file_name, "wb") as f:
+        f.write(original_bytes)
 
     # Get any additional args as specified by an .args file
     additional_args: list[str] = []
     if os.path.exists(test_file.replace(".py", ".args")):
-        with open(test_file.replace(".py", ".args"), encoding="utf-8") as args_file:
-            additional_args = [i.rstrip("\n") for i in args_file.readlines()]
+        with open(test_file.replace(".py", ".args"), encoding="utf-8") as f:
+            additional_args = [i.rstrip("\n") for i in f.readlines()]
 
     pydocstringformatter.run_docstring_formatter(
         [temp_file_name, "--write"] + additional_args
@@ -59,5 +62,5 @@ def test_formatting(
 
     output = capsys.readouterr()
     assert not output.err
-    with open(temp_file_name, encoding="utf-8") as temp_file:
-        assert temp_file.readlines() == expected_lines
+    with open(temp_file_name, "rb") as f:
+        assert f.read() == expected_output


### PR DESCRIPTION
Here's my proposed solution. It should work in all cases, as it will default to the system default, if the file has different line endings (`file.newlines` returns a tuple).

I manually tested it with Unix, Dos, and Mac formatted files, and they all retained their line endings.