### PR TITLE
ENH: Add formatters for numpydoc section ordering and name/type spacing

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -9,7 +9,7 @@ Current usage of ``pydocstringformatter``:
                                 [--exit-code] [--max-summary-lines int]
                                 [--summary-quotes-same-line]
                                 [--max-line-length int]
-                                [--style {pep257} [{pep257} ...]]
+                                [--style {pep257,numpydoc} [{pep257,numpydoc} ...]]
                                 [--strip-whitespaces  --no-strip-whitespaces]
                                 [--split-summary-body  --no-split-summary-body]
                                 [--linewrap-full-docstring  --no-linewrap-full-docstring]
@@ -45,7 +45,7 @@ Current usage of ``pydocstringformatter``:
                             is enforced for single line docstrings.
       --max-line-length int
                             Maximum line length of docstrings.
-      --style {pep257} [{pep257} ...]
+      --style {pep257,numpydoc} [{pep257,numpydoc} ...]
                             Docstring styles that are used in the project. Can be
                             more than one.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -18,6 +18,10 @@ Current usage of ``pydocstringformatter``:
                                 [--capitalize-first-letter  --no-capitalize-first-letter]
                                 [--final-period  --no-final-period]
                                 [--quotes-type  --no-quotes-type]
+                                [--numpydoc-section-order  --no-numpydoc-section-order]
+                                [--numpydoc-name-type-spacing  --no-numpydoc-name-type-spacing]
+                                [--numpydoc-section-spacing  --no-numpydoc-section-spacing]
+                                [--numpydoc-section-hyphen-length  --no-numpydoc-section-hyphen-length]
                                 [files ...]
 
     positional arguments:
@@ -82,6 +86,22 @@ Current usage of ``pydocstringformatter``:
                             Activate or deactivate quotes-type: Change all opening
                             and closing quotes to be triple quotes. Styles:
                             default. (default: True)
+      --numpydoc-section-order, --no-numpydoc-section-order
+                            Activate or deactivate numpydoc-section-order: Change
+                            section order to match numpydoc guidelines. Styles:
+                            numpydoc. (default: True)
+      --numpydoc-name-type-spacing, --no-numpydoc-name-type-spacing
+                            Activate or deactivate numpydoc-name-type-spacing:
+                            Ensure proper spacing around the colon separating
+                            names from types. Styles: numpydoc. (default: True)
+      --numpydoc-section-spacing, --no-numpydoc-section-spacing
+                            Activate or deactivate numpydoc-section-spacing:
+                            Ensure proper spacing between sections. Styles:
+                            numpydoc. (default: True)
+      --numpydoc-section-hyphen-length, --no-numpydoc-section-hyphen-length
+                            Activate or deactivate numpydoc-section-hyphen-length:
+                            Ensure hyphens after section header lines are proper
+                            length. Styles: numpydoc. (default: True)
 
     optional formatters:
       these formatters are turned off by default

--- a/pydocstringformatter/_configuration/arguments_manager.py
+++ b/pydocstringformatter/_configuration/arguments_manager.py
@@ -123,7 +123,7 @@ class ArgumentsManager:
             action="extend",
             type=str,
             nargs="+",
-            choices=["pep257"],
+            choices=["pep257", "numpydoc"],
             help="Docstring styles that are used in the project. Can be more than one.",
         )
 

--- a/pydocstringformatter/_formatting/__init__.py
+++ b/pydocstringformatter/_formatting/__init__.py
@@ -13,6 +13,12 @@ from pydocstringformatter._formatting.formatters_default import (
     QuotesTypeFormatter,
     StripWhitespacesFormatter,
 )
+from pydocstringformatter._formatting.formatters_numpydoc import (
+    NumpydocNameColonTypeFormatter,
+    NumpydocSectionHyphenLengthFormatter,
+    NumpydocSectionOrderingFormatter,
+    NumpydocSectionSpacingFormatter,
+)
 from pydocstringformatter._formatting.formatters_pep257 import (
     SplitSummaryAndDocstringFormatter,
 )
@@ -31,4 +37,8 @@ FORMATTERS: list[Formatter] = [
     CapitalizeFirstLetterFormatter(),
     FinalPeriodFormatter(),
     QuotesTypeFormatter(),
+    NumpydocSectionOrderingFormatter(),
+    NumpydocNameColonTypeFormatter(),
+    NumpydocSectionSpacingFormatter(),
+    NumpydocSectionHyphenLengthFormatter(),
 ]

--- a/pydocstringformatter/_formatting/formatters_numpydoc.py
+++ b/pydocstringformatter/_formatting/formatters_numpydoc.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from pydocstringformatter._formatting.base import NumpydocSectionFormatter
+
+
+class NumpydocSectionOrderingFormatter(NumpydocSectionFormatter):
+    """Change section order to match numpydoc guidelines."""
+
+    name = "numpydoc-section-order"
+
+    numpydoc_section_order = (
+        "Summary",
+        "Parameters",
+        "Attributes",
+        "Methods",
+        "Returns",
+        "Yields",
+        "Receives",
+        "Other Parameters",
+        "Raises",
+        "Warns",
+        "Warnings",
+        "See Also",
+        "Notes",
+        "References",
+        "Examples",
+    )
+
+    def treat_sections(
+        self, sections: OrderedDict[str, list[str]]
+    ) -> OrderedDict[str, list[str]]:
+        """Sort the numpydoc sections into the numpydoc order."""
+        for sec_name in reversed(self.numpydoc_section_order):
+            try:
+                sections.move_to_end(sec_name, last=False)
+            except KeyError:
+                pass
+        return sections
+
+
+class NumpydocNameColonTypeFormatter(NumpydocSectionFormatter):
+    """Ensure proper spacing around the colon separating names from types."""
+
+    name = "numpydoc-name-type-spacing"
+
+    numpydoc_sections_with_parameters = (
+        "Parameters",
+        "Attributes",
+        "Returns",
+        "Yields",
+        "Receives",
+        "Other Parameters",
+        "See Also",
+    )
+
+    def treat_sections(
+        self, sections: OrderedDict[str, list[str]]
+    ) -> OrderedDict[str, list[str]]:
+        """Ensure proper spacing around the colon separating names from types."""
+        for section_name, section_lines in sections.items():
+            if section_name in self.numpydoc_sections_with_parameters:
+                # Any section that gets here has a line of hyphens
+                initial_indent = section_lines[1].index("-")
+                for index, line in enumerate(section_lines):
+                    if (
+                        # There is content on this line (at least the initial indent)
+                        len(line) > initial_indent
+                        # and the first character after the indent for
+                        # the docstring is a name, not an additional
+                        # indent indicating a description rather than
+                        # a line with name and type
+                        and not line[initial_indent].isspace()
+                        # and there is a colon to separate the name
+                        # from the type (functions returning only one
+                        # thing don't put a name in their "Returns"
+                        # section)
+                        and ":" in line
+                    ):
+                        line_name, line_type = line.split(":", 1)
+                        if line_type:
+                            # Avoid adding trailing whitespace
+                            # Colon ending first line is suggested for long
+                            # "See Also" links
+                            section_lines[
+                                index
+                            ] = f"{line_name.rstrip():s} : {line_type.lstrip():s}"
+        return sections
+
+
+class NumpydocSectionSpacingFormatter(NumpydocSectionFormatter):
+    """Ensure proper spacing between sections."""
+
+    name = "numpydoc-section-spacing"
+
+    def treat_sections(
+        self, sections: OrderedDict[str, list[str]]
+    ) -> OrderedDict[str, list[str]]:
+        """Ensure proper spacing between sections."""
+        for section_lines in sections.values():
+            last_line = section_lines[-1]
+            if not (last_line == "" or last_line.isspace()):
+                section_lines.append("")
+        return sections
+
+
+class NumpydocSectionHyphenLengthFormatter(NumpydocSectionFormatter):
+    """Ensure hyphens after section header lines are proper length."""
+
+    name = "numpydoc-section-hyphen-length"
+
+    def treat_sections(
+        self, sections: OrderedDict[str, list[str]]
+    ) -> OrderedDict[str, list[str]]:
+        """Ensure section header lines are proper length."""
+        first_section = True
+        for section_name, section_lines in sections.items():
+            if section_name != "Summary":
+                # Skip the summary, deprecation warning and extended
+                # summary.  They have neither a section header nor the
+                # line of hyphens after it.
+                indent_length = section_lines[1].index("-")
+                section_lines[1] = " " * indent_length + "-" * len(section_name)
+                if first_section:
+                    # If the second line were not hyphens, the section name
+                    # would be summary.  This assumes triple quotes, but that
+                    # seems fine for a multi-line docstring.
+                    section_lines[1] = f"{section_lines[1]:s}---"
+            first_section = False
+        return sections

--- a/tests/data/format/numpydoc/numpydoc_header_line.args
+++ b/tests/data/format/numpydoc/numpydoc_header_line.args
@@ -1,0 +1,6 @@
+--style=numpydoc
+--no-numpydoc-name-type-spacing
+--no-numpydoc-section-order
+--no-numpydoc-section-spacing
+--no-final-period
+--no-closing-quotes

--- a/tests/data/format/numpydoc/numpydoc_header_line.py
+++ b/tests/data/format/numpydoc/numpydoc_header_line.py
@@ -1,0 +1,1 @@
+numpydoc_style.py

--- a/tests/data/format/numpydoc/numpydoc_header_line.py.out
+++ b/tests/data/format/numpydoc/numpydoc_header_line.py.out
@@ -1,0 +1,63 @@
+"""Example module for numpydoc docstring style.
+References
+----------
+NumPy docstring style guide:
+https://numpydoc.readthedocs.io/en/latest/format.html#documenting-modules"""
+import math
+
+EULER_NUMBER = math.e
+"""Euler's number.
+
+Not related to Euler's constant (sometimes called the Euler-Mascheroni
+constant.
+References
+----------
+E (mathematical constant)
+https://en.wikipedia.org/wiki/E_(mathematical_constant)
+Notes
+-----
+It is the limit of ``(1 + 1/n)**n`` as n approaches infinity, so it
+is used in the equation for continuously-compouned interest.
+
+It is also the sum of the reciprocals of the whole numbers starting
+with zero, which is related to some calculus-related properties
+mathemeticians find elegant.
+"""
+
+
+def sincos(theta):
+    """Returns
+    ----------
+    sin: float
+        the sine of theta
+    cos: float
+        the cosine of theta
+    Raises
+    ------
+    TypeError
+        If `theta` is not a float.
+    Parameters
+    ----------
+    theta: float
+        the angle at which to calculate the sine and cosine.
+    """
+    return math.sin(theta), math.cos(theta)
+
+
+def fibbonacci():
+    """Generate the Fibonacci sequence.
+
+    Each term is the sum of the two previous; conventionally starts
+    with two ones.
+    References
+    ----------
+    Fibonacci numbers
+    https://en.wikipedia.org/wiki/Fibonacci_number
+    Yields
+    ------
+    int"""
+    curr = 1
+    last = 0
+    while True:
+        yield curr
+        curr, last = curr + last, curr

--- a/tests/data/format/numpydoc/numpydoc_parameter_spacing.args
+++ b/tests/data/format/numpydoc/numpydoc_parameter_spacing.args
@@ -1,0 +1,7 @@
+--style=numpydoc
+--numpydoc-name-type-spacing
+--no-numpydoc-section-order
+--no-numpydoc-section-spacing
+--no-numpydoc-section-hyphen-length
+--no-final-period
+--no-closing-quotes

--- a/tests/data/format/numpydoc/numpydoc_parameter_spacing.py
+++ b/tests/data/format/numpydoc/numpydoc_parameter_spacing.py
@@ -1,0 +1,1 @@
+numpydoc_style.py

--- a/tests/data/format/numpydoc/numpydoc_parameter_spacing.py.out
+++ b/tests/data/format/numpydoc/numpydoc_parameter_spacing.py.out
@@ -1,0 +1,63 @@
+"""Example module for numpydoc docstring style.
+References
+-----
+NumPy docstring style guide:
+https://numpydoc.readthedocs.io/en/latest/format.html#documenting-modules"""
+import math
+
+EULER_NUMBER = math.e
+"""Euler's number.
+
+Not related to Euler's constant (sometimes called the Euler-Mascheroni
+constant.
+References
+-----
+E (mathematical constant)
+https://en.wikipedia.org/wiki/E_(mathematical_constant)
+Notes
+---
+It is the limit of ``(1 + 1/n)**n`` as n approaches infinity, so it
+is used in the equation for continuously-compouned interest.
+
+It is also the sum of the reciprocals of the whole numbers starting
+with zero, which is related to some calculus-related properties
+mathemeticians find elegant.
+"""
+
+
+def sincos(theta):
+    """Returns
+    ----
+    sin : float
+        the sine of theta
+    cos : float
+        the cosine of theta
+    Raises
+    ---
+    TypeError
+        If `theta` is not a float.
+    Parameters
+    -----
+    theta : float
+        the angle at which to calculate the sine and cosine.
+    """
+    return math.sin(theta), math.cos(theta)
+
+
+def fibbonacci():
+    """Generate the Fibonacci sequence.
+
+    Each term is the sum of the two previous; conventionally starts
+    with two ones.
+    References
+    -----
+    Fibonacci numbers
+    https://en.wikipedia.org/wiki/Fibonacci_number
+    Yields
+    ---
+    int"""
+    curr = 1
+    last = 0
+    while True:
+        yield curr
+        curr, last = curr + last, curr

--- a/tests/data/format/numpydoc/numpydoc_section_ordering.args
+++ b/tests/data/format/numpydoc/numpydoc_section_ordering.args
@@ -1,0 +1,6 @@
+--style=numpydoc
+--no-numpydoc-name-type-spacing
+--no-numpydoc-section-spacing
+--no-numpydoc-section-hyphen-length
+--no-final-period
+--no-closing-quotes

--- a/tests/data/format/numpydoc/numpydoc_section_ordering.py
+++ b/tests/data/format/numpydoc/numpydoc_section_ordering.py
@@ -1,0 +1,1 @@
+numpydoc_style.py

--- a/tests/data/format/numpydoc/numpydoc_section_ordering.py.out
+++ b/tests/data/format/numpydoc/numpydoc_section_ordering.py.out
@@ -1,0 +1,63 @@
+"""Example module for numpydoc docstring style.
+References
+-----
+NumPy docstring style guide:
+https://numpydoc.readthedocs.io/en/latest/format.html#documenting-modules"""
+import math
+
+EULER_NUMBER = math.e
+"""Euler's number.
+
+Not related to Euler's constant (sometimes called the Euler-Mascheroni
+constant.
+Notes
+---
+It is the limit of ``(1 + 1/n)**n`` as n approaches infinity, so it
+is used in the equation for continuously-compouned interest.
+
+It is also the sum of the reciprocals of the whole numbers starting
+with zero, which is related to some calculus-related properties
+mathemeticians find elegant.
+
+References
+-----
+E (mathematical constant)
+https://en.wikipedia.org/wiki/E_(mathematical_constant)"""
+
+
+def sincos(theta):
+    """Parameters
+    -----
+    theta: float
+        the angle at which to calculate the sine and cosine.
+
+    Returns
+    ----
+    sin: float
+        the sine of theta
+    cos: float
+        the cosine of theta
+    Raises
+    ---
+    TypeError
+        If `theta` is not a float."""
+    return math.sin(theta), math.cos(theta)
+
+
+def fibbonacci():
+    """Generate the Fibonacci sequence.
+
+    Each term is the sum of the two previous; conventionally starts
+    with two ones.
+    Yields
+    ---
+    int
+    References
+    -----
+    Fibonacci numbers
+    https://en.wikipedia.org/wiki/Fibonacci_number"""
+    curr = 1
+    last = 0
+    while True:
+        yield curr
+        curr, last = curr + last, curr

--- a/tests/data/format/numpydoc/numpydoc_section_spacing.args
+++ b/tests/data/format/numpydoc/numpydoc_section_spacing.args
@@ -1,0 +1,6 @@
+--style=numpydoc
+--no-numpydoc-name-type-spacing
+--no-numpydoc-section-order
+--no-numpydoc-section-hyphen-length
+--no-final-period
+--no-closing-quotes

--- a/tests/data/format/numpydoc/numpydoc_section_spacing.py
+++ b/tests/data/format/numpydoc/numpydoc_section_spacing.py
@@ -1,0 +1,1 @@
+numpydoc_style.py

--- a/tests/data/format/numpydoc/numpydoc_section_spacing.py.out
+++ b/tests/data/format/numpydoc/numpydoc_section_spacing.py.out
@@ -1,0 +1,72 @@
+"""Example module for numpydoc docstring style.
+
+References
+-----
+NumPy docstring style guide:
+https://numpydoc.readthedocs.io/en/latest/format.html#documenting-modules
+"""
+import math
+
+EULER_NUMBER = math.e
+"""Euler's number.
+
+Not related to Euler's constant (sometimes called the Euler-Mascheroni
+constant.
+
+References
+-----
+E (mathematical constant)
+https://en.wikipedia.org/wiki/E_(mathematical_constant)
+
+Notes
+---
+It is the limit of ``(1 + 1/n)**n`` as n approaches infinity, so it
+is used in the equation for continuously-compouned interest.
+
+It is also the sum of the reciprocals of the whole numbers starting
+with zero, which is related to some calculus-related properties
+mathemeticians find elegant.
+"""
+
+
+def sincos(theta):
+    """Returns
+    ----
+    sin: float
+        the sine of theta
+    cos: float
+        the cosine of theta
+
+    Raises
+    ---
+    TypeError
+        If `theta` is not a float.
+
+    Parameters
+    -----
+    theta: float
+        the angle at which to calculate the sine and cosine.
+    """
+    return math.sin(theta), math.cos(theta)
+
+
+def fibbonacci():
+    """Generate the Fibonacci sequence.
+
+    Each term is the sum of the two previous; conventionally starts
+    with two ones.
+
+    References
+    -----
+    Fibonacci numbers
+    https://en.wikipedia.org/wiki/Fibonacci_number
+
+    Yields
+    ---
+    int
+    """
+    curr = 1
+    last = 0
+    while True:
+        yield curr
+        curr, last = curr + last, curr

--- a/tests/data/format/numpydoc/numpydoc_style.args
+++ b/tests/data/format/numpydoc/numpydoc_style.args
@@ -1,0 +1,3 @@
+--style=numpydoc
+--no-final-period
+--no-closing-quotes

--- a/tests/data/format/numpydoc/numpydoc_style.py
+++ b/tests/data/format/numpydoc/numpydoc_style.py
@@ -1,0 +1,63 @@
+"""Example module for numpydoc docstring style.
+References
+-----
+NumPy docstring style guide:
+https://numpydoc.readthedocs.io/en/latest/format.html#documenting-modules"""
+import math
+
+EULER_NUMBER = math.e
+"""Euler's number.
+
+Not related to Euler's constant (sometimes called the Euler-Mascheroni
+constant.
+References
+-----
+E (mathematical constant)
+https://en.wikipedia.org/wiki/E_(mathematical_constant)
+Notes
+---
+It is the limit of ``(1 + 1/n)**n`` as n approaches infinity, so it
+is used in the equation for continuously-compouned interest.
+
+It is also the sum of the reciprocals of the whole numbers starting
+with zero, which is related to some calculus-related properties
+mathemeticians find elegant.
+"""
+
+
+def sincos(theta):
+    """Returns
+    ----
+    sin: float
+        the sine of theta
+    cos: float
+        the cosine of theta
+    Raises
+    ---
+    TypeError
+        If `theta` is not a float.
+    Parameters
+    -----
+    theta: float
+        the angle at which to calculate the sine and cosine.
+"""
+    return math.sin(theta), math.cos(theta)
+
+
+def fibbonacci():
+    """Generate the Fibonacci sequence.
+
+    Each term is the sum of the two previous; conventionally starts
+    with two ones.
+    References
+    -----
+    Fibonacci numbers
+    https://en.wikipedia.org/wiki/Fibonacci_number
+    Yields
+    ---
+    int"""
+    curr = 1
+    last = 0
+    while True:
+        yield curr
+        curr, last = curr + last, curr

--- a/tests/data/format/numpydoc/numpydoc_style.py.out
+++ b/tests/data/format/numpydoc/numpydoc_style.py.out
@@ -1,0 +1,72 @@
+"""Example module for numpydoc docstring style.
+
+References
+----------
+NumPy docstring style guide:
+https://numpydoc.readthedocs.io/en/latest/format.html#documenting-modules
+"""
+import math
+
+EULER_NUMBER = math.e
+"""Euler's number.
+
+Not related to Euler's constant (sometimes called the Euler-Mascheroni
+constant.
+
+Notes
+-----
+It is the limit of ``(1 + 1/n)**n`` as n approaches infinity, so it
+is used in the equation for continuously-compouned interest.
+
+It is also the sum of the reciprocals of the whole numbers starting
+with zero, which is related to some calculus-related properties
+mathemeticians find elegant.
+
+References
+----------
+E (mathematical constant)
+https://en.wikipedia.org/wiki/E_(mathematical_constant)
+"""
+
+
+def sincos(theta):
+    """Parameters
+    -------------
+    theta : float
+        the angle at which to calculate the sine and cosine.
+
+    Returns
+    -------
+    sin : float
+        the sine of theta
+    cos : float
+        the cosine of theta
+
+    Raises
+    ------
+    TypeError
+        If `theta` is not a float.
+    """
+    return math.sin(theta), math.cos(theta)
+
+
+def fibbonacci():
+    """Generate the Fibonacci sequence.
+
+    Each term is the sum of the two previous; conventionally starts
+    with two ones.
+
+    Yields
+    ------
+    int
+
+    References
+    ----------
+    Fibonacci numbers
+    https://en.wikipedia.org/wiki/Fibonacci_number
+    """
+    curr = 1
+    last = 0
+    while True:
+        yield curr
+        curr, last = curr + last, curr

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -241,6 +241,11 @@ class TestStyleOption:
         run = _Run([test_file, "--style", "pep257"])
         assert run.config.style == ["pep257"]
 
+    def test_style_numpydoc_only(self, test_file: str) -> None:
+        """Test that we can specify only a non-default style."""
+        run = _Run([test_file, "--style", "numpydoc"])
+        assert ["numpydoc"] == run.config.style
+
     def test_style_invalid_choice(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Test that we correctly reject invalid styles."""
         with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
Related to #125; I got the bits I could think how to automate for the docstring style I actually use ([numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard))

Should probably extend the tests for more types of docstrings and more sections within each docstring.

Ideally the section test would have docstrings on
- [X] function
- [ ] class
- [ ] method
- [x] generator
- [x] module
- [x] constant

and would test the ordering of some subset of these sections:
- [X] Parameters
- [X] Returns
- [X] Raises
- [ ] Examples
- [x] Yields
- [x] References

Formatters for:
- [X] name-colon parameter spacing (`x : float` not `x:float` or `x: float`)
- [X] Section ordering
- [x] Section spacing (blank line between sections)
- [x] Length of line of hyphens after section header (should be same length as section header)