### PR TITLE
Fix ``tomli`` vs ``tomllib`` import

### DIFF
--- a/pydocstringformatter/__init__.py
+++ b/pydocstringformatter/__init__.py
@@ -8,7 +8,7 @@ from pydocstringformatter._utils.exceptions import (
     PydocstringFormatterError,
 )
 
-__version__ = "0.8.0-dev"
+__version__ = "0.7.1"
 
 
 def run_docstring_formatter(argv: list[str] | None = None) -> None:

--- a/pydocstringformatter/__init__.py
+++ b/pydocstringformatter/__init__.py
@@ -8,7 +8,7 @@ from pydocstringformatter._utils.exceptions import (
     PydocstringFormatterError,
 )
 
-__version__ = "0.7.1"
+__version__ = "0.8.0-dev"
 
 
 def run_docstring_formatter(argv: list[str] | None = None) -> None:

--- a/pydocstringformatter/_configuration/toml_parsing.py
+++ b/pydocstringformatter/_configuration/toml_parsing.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from typing import Any
 
-import tomli
-
 from pydocstringformatter._utils.exceptions import TomlParsingError, UnrecognizedOption
+
+if sys.version_info <= (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
 
 
 def get_toml_file() -> dict[str, Any] | None:
@@ -14,8 +18,8 @@ def get_toml_file() -> dict[str, Any] | None:
     if os.path.isfile("pyproject.toml"):
         with open("pyproject.toml", "rb") as file:
             try:
-                toml_dict = tomli.load(file)
-            except tomli.TOMLDecodeError as exc:
+                toml_dict = tomllib.load(file)
+            except tomllib.TOMLDecodeError as exc:
                 raise TomlParsingError from exc
             if tool_section := toml_dict.get("tool", None):
                 if pydocformat_sect := tool_section.get("pydocstringformatter", None):


### PR DESCRIPTION
Don't know how I didn't notice this sooner...

Releasing `0.7.1` immediately after.