### PR TITLE
added boolean optional argument support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ exclude = "**/my_dir/**,**/my_other_dir/**"
 exclude = ["**/my_dir/**", "**/my_other_dir/**"]
 strip-whitespaces = true
 split-summary-body = false
-no-numpydoc-section-hyphen-length = true
+numpydoc-section-hyphen-length = false
 ```
 
 #### Style

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ write = true
 exclude = "**/my_dir/**,**/my_other_dir/**"
 # Or:
 exclude = ["**/my_dir/**", "**/my_other_dir/**"]
+strip-whitespaces = true
+split-summary-body = false
+no-numpydoc-section-hyphen-length = true
 ```
 
 #### Style

--- a/pydocstringformatter/_configuration/toml_parsing.py
+++ b/pydocstringformatter/_configuration/toml_parsing.py
@@ -49,7 +49,8 @@ def parse_toml_option(
 
         if opt.startswith("no") and f"--{opt[3:]}" in option_strings:
             opposite_opt = opt[3:]
-            val, opp_val = ["false", "true"][value], ["true", "false"][value]
+            val = ["false", "true"][bool(value)]
+            opp_val = ["true", "false"][bool(value)]
             error_msg = (
                 "TOML file contains an unsupported option "
                 f"'{opt}: {val}', try using '{opposite_opt}: {opp_val}' instead"

--- a/pydocstringformatter/_configuration/toml_parsing.py
+++ b/pydocstringformatter/_configuration/toml_parsing.py
@@ -49,7 +49,7 @@ def parse_toml_option(  # pylint: disable=too-many-branches
 
         if not isinstance(value, bool):
             error_msg = f"{{'{value}'}} {type(value)} is not a supported argument for"
-            error_msg += f"'{opt}', please use either {{true}} or {{false}}."
+            error_msg += f" '{opt}', please use either {{true}} or {{false}}."
             raise ValueError(error_msg)
 
         if opt.startswith("no") and f"--{opt[3:]}" in option_strings:
@@ -62,9 +62,7 @@ def parse_toml_option(  # pylint: disable=too-many-branches
             )
             raise TomlParsingError(error_msg)
 
-        index = option_strings.index(f"--{'no-' if not value else ''}{opt}")
-        option = action.option_strings[index]
-        return [option]
+        return [f"--{'no-' if not value else ''}{opt}"]
 
     if isinstance(action, argparse._StoreTrueAction):
         if value is True:

--- a/pydocstringformatter/_configuration/toml_parsing.py
+++ b/pydocstringformatter/_configuration/toml_parsing.py
@@ -45,14 +45,12 @@ def parse_toml_option(  # pylint: disable=too-many-branches
             raise UnrecognizedOption(f"Don't recognize option {opt}") from exc
 
     if isinstance(action, BooleanOptionalAction):
-        option_strings = action.option_strings
-
         if not isinstance(value, bool):
             error_msg = f"{{'{value}'}} {type(value)} is not a supported argument for"
             error_msg += f" '{opt}', please use either {{true}} or {{false}}."
             raise ValueError(error_msg)
 
-        if opt.startswith("no") and f"--{opt[3:]}" in option_strings:
+        if opt.startswith("no") and f"--{opt[3:]}" in action.option_strings:
             opposite_opt = opt[3:]
             val = ["false", "true"][value]
             opp_val = ["true", "false"][value]

--- a/pydocstringformatter/_configuration/toml_parsing.py
+++ b/pydocstringformatter/_configuration/toml_parsing.py
@@ -5,6 +5,9 @@ import os
 import sys
 from typing import Any
 
+from pydocstringformatter._configuration.boolean_option_action import (
+    BooleanOptionalAction,
+)
 from pydocstringformatter._utils.exceptions import TomlParsingError, UnrecognizedOption
 
 if sys.version_info <= (3, 11):
@@ -40,6 +43,11 @@ def parse_toml_option(
             action = parser._option_string_actions[f"-{opt}"]
         except KeyError:
             raise UnrecognizedOption(f"Don't recognize option {opt}") from exc
+
+    if isinstance(action, BooleanOptionalAction):
+        index = action.option_strings.index(f"--{opt}")
+        option = action.option_strings[index]
+        return [option]
 
     if isinstance(action, argparse._StoreTrueAction):
         if value is True:

--- a/pydocstringformatter/_configuration/toml_parsing.py
+++ b/pydocstringformatter/_configuration/toml_parsing.py
@@ -45,7 +45,18 @@ def parse_toml_option(
             raise UnrecognizedOption(f"Don't recognize option {opt}") from exc
 
     if isinstance(action, BooleanOptionalAction):
-        index = action.option_strings.index(f"--{opt}")
+        option_strings = action.option_strings
+
+        if opt.startswith("no") and f"--{opt[3:]}" in option_strings:
+            opposite_opt = opt[3:]
+            val, opp_val = ["false", "true"][value], ["true", "false"][value]
+            error_msg = (
+                "TOML file contains an unsupported option "
+                f"'{opt}: {val}', try using '{opposite_opt}: {opp_val}' instead"
+            )
+            raise TomlParsingError(error_msg)
+
+        index = option_strings.index(f"--{'no-' if not value else ''}{opt}")
         option = action.option_strings[index]
         return [option]
 

--- a/pydocstringformatter/_configuration/toml_parsing.py
+++ b/pydocstringformatter/_configuration/toml_parsing.py
@@ -54,8 +54,8 @@ def parse_toml_option(  # pylint: disable=too-many-branches
 
         if opt.startswith("no") and f"--{opt[3:]}" in option_strings:
             opposite_opt = opt[3:]
-            val = ["false", "true"][bool(value)]
-            opp_val = ["true", "false"][bool(value)]
+            val = ["false", "true"][value]
+            opp_val = ["true", "false"][value]
             error_msg = (
                 "TOML file contains an unsupported option "
                 f"'{opt}: {val}', try using '{opposite_opt}: {opp_val}' instead"

--- a/pydocstringformatter/_configuration/toml_parsing.py
+++ b/pydocstringformatter/_configuration/toml_parsing.py
@@ -31,7 +31,7 @@ def get_toml_file() -> dict[str, Any] | None:
     return None
 
 
-def parse_toml_option(
+def parse_toml_option(  # pylint: disable=too-many-branches
     parser: argparse.ArgumentParser, opt: str, value: Any
 ) -> list[str]:
     """Parse an options value in the correct argument type for argparse."""
@@ -46,6 +46,11 @@ def parse_toml_option(
 
     if isinstance(action, BooleanOptionalAction):
         option_strings = action.option_strings
+
+        if not isinstance(value, bool):
+            error_msg = f"{{'{value}'}} {type(value)} is not a supported argument for"
+            error_msg += f"'{opt}', please use either {{true}} or {{false}}."
+            raise ValueError(error_msg)
 
         if opt.startswith("no") and f"--{opt[3:]}" in option_strings:
             opposite_opt = opt[3:]

--- a/tests/data/config/non_valid_toml_boolopt/pyproject.toml
+++ b/tests/data/config/non_valid_toml_boolopt/pyproject.toml
@@ -3,4 +3,4 @@ write = false
 style = ["numpydoc"]
 strip-whitespaces = true
 split-summary-body = false
-numpydoc-section-hyphen-length = false
+no-numpydoc-section-hyphen-length = true

--- a/tests/data/config/non_valid_toml_boolopt/test_package/numpydoc_style.py
+++ b/tests/data/config/non_valid_toml_boolopt/test_package/numpydoc_style.py
@@ -1,0 +1,3 @@
+def func():
+    """
+    A docstring"""

--- a/tests/data/config/non_valid_toml_boolopt_two/pyproject.toml
+++ b/tests/data/config/non_valid_toml_boolopt_two/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pydocstringformatter]
+write = false
+style = ["numpydoc"]
+strip-whitespaces = true
+split-summary-body = false
+numpydoc-section-hyphen-length = 'true'

--- a/tests/data/config/non_valid_toml_boolopt_two/test_package/numpydoc_style.py
+++ b/tests/data/config/non_valid_toml_boolopt_two/test_package/numpydoc_style.py
@@ -1,0 +1,3 @@
+def func():
+    """
+    A docstring"""

--- a/tests/data/config/valid_toml_boolopt/pyproject.toml
+++ b/tests/data/config/valid_toml_boolopt/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pydocstringformatter]
+write = false
+style = ["numpydoc"]
+strip-whitespaces = true
+split-summary-body = false
+no-numpydoc-section-hyphen-length = true

--- a/tests/data/config/valid_toml_boolopt/test_package/numpydoc_style.py
+++ b/tests/data/config/valid_toml_boolopt/test_package/numpydoc_style.py
@@ -1,0 +1,3 @@
+def func():
+    """
+    A docstring"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -269,3 +269,13 @@ class TestStyleOption:
         monkeypatch.chdir(CONFIG_DATA / "valid_toml_numpydoc_pep257")
         run = _Run(["test_package"])
         assert run.config.style == ["numpydoc", "pep257"]
+
+    def test_boolopt_in_toml(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that arguments of type BooleanOptionalAction work in toml files."""
+        monkeypatch.chdir(CONFIG_DATA / "valid_toml_boolopt")
+        run = _Run(["test_package"])
+        assert not run.config.summary_quotes_same_line
+
+        # dashes in the name dont allow the dot notation to get this value
+        assert not run.config.__dict__["numpydoc-section-hyphen-length"]
+        assert run.config.__dict__["strip-whitespaces"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -279,3 +279,17 @@ class TestStyleOption:
         # dashes in the name dont allow the dot notation to get this value
         assert not run.config.__dict__["numpydoc-section-hyphen-length"]
         assert run.config.__dict__["strip-whitespaces"]
+
+    def test_non_valid_boolopt_in_toml(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that '--no' versions arguments in toml do not work."""
+        monkeypatch.chdir(CONFIG_DATA / "non_valid_toml_boolopt")
+        with pytest.raises(exceptions.TomlParsingError) as err:
+            _Run(["test_package"])
+
+        error_msg = (
+            "TOML file contains an unsupported option "
+            "'no-numpydoc-section-hyphen-length: true', try using "
+            "'numpydoc-section-hyphen-length: false' instead"
+        )
+
+        assert error_msg in str(err.value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -302,7 +302,7 @@ class TestStyleOption:
 
         error_msg = (
             "{'true'} <class 'str'> is not a supported argument"
-            " for'numpydoc-section-hyphen-length',"
+            " for 'numpydoc-section-hyphen-length',"
             " please use either {true} or {false}."
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -281,7 +281,7 @@ class TestStyleOption:
         assert run.config.__dict__["strip-whitespaces"]
 
     def test_non_valid_boolopt_in_toml(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Test that '--no' versions arguments in toml do not work."""
+        """Test that '--no' versions of BooleanOptionalAction in toml do not work."""
         monkeypatch.chdir(CONFIG_DATA / "non_valid_toml_boolopt")
         with pytest.raises(exceptions.TomlParsingError) as err:
             _Run(["test_package"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -293,3 +293,17 @@ class TestStyleOption:
         )
 
         assert error_msg in str(err.value)
+
+    def test_non_bool_boolopt_in_toml(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that non-bool values of BooleanOptionalAction in toml do not work."""
+        monkeypatch.chdir(CONFIG_DATA / "non_valid_toml_boolopt_two")
+        with pytest.raises(ValueError) as err:
+            _Run(["test_package"])
+
+        error_msg = (
+            "{'true'} <class 'str'> is not a supported argument"
+            " for'numpydoc-section-hyphen-length',"
+            " please use either {true} or {false}."
+        )
+
+        assert error_msg in str(err.value)


### PR DESCRIPTION

Improved the toml parsing so it supports `BooleanOptionalAction` arguments in it.
(also added tests for it ...)

```toml
[tool.pydocstringformatter]
write = false
style = ["numpydoc"]
strip-whitespaces = true  # <<<<<- previously unsupported
split-summary-body = false # <<<<<- previously unsupported
no-numpydoc-section-hyphen-length = true # <<<<<- previously unsupported
```

.... where should I document this?