### PR TITLE
Feature: two-pass formatting of the tokens

### DIFF
--- a/pydocstringformatter/_testutils/__init__.py
+++ b/pydocstringformatter/_testutils/__init__.py
@@ -10,6 +10,7 @@ import pytest
 from pydocstringformatter import run_docstring_formatter
 from pydocstringformatter._formatting import Formatter
 from pydocstringformatter._testutils.example_formatters import (
+    AddBFormatter,
     MakeAFormatter,
     MakeBFormatter,
 )
@@ -83,4 +84,4 @@ Temp file is '{self.file_to_format}'
         return None
 
 
-__all__ = ["FormatterAsserter", "MakeAFormatter", "MakeBFormatter"]
+__all__ = ["FormatterAsserter", "MakeAFormatter", "MakeBFormatter", "AddBFormatter"]

--- a/pydocstringformatter/_testutils/example_formatters.py
+++ b/pydocstringformatter/_testutils/example_formatters.py
@@ -27,3 +27,16 @@ class MakeBFormatter(Formatter):
         token_dict = tokeninfo._asdict()
         token_dict["string"] = token_dict["string"].replace("A", "B")
         return type(tokeninfo)(**token_dict)
+
+
+class AddBFormatter(Formatter):
+    """A formatter that adds Bs."""
+
+    name = "add-b-formatter"
+    style = ["default"]
+
+    def treat_token(self, tokeninfo: tokenize.TokenInfo) -> tokenize.TokenInfo:
+        """Add a B to the end of the string."""
+        token_dict = tokeninfo._asdict()
+        token_dict["string"] += "B"
+        return type(tokeninfo)(**token_dict)

--- a/pydocstringformatter/_utils/__init__.py
+++ b/pydocstringformatter/_utils/__init__.py
@@ -7,6 +7,7 @@ from pydocstringformatter._utils.exceptions import (
 from pydocstringformatter._utils.file_diference import compare_formatters, generate_diff
 from pydocstringformatter._utils.find_docstrings import is_docstring
 from pydocstringformatter._utils.find_python_file import find_python_files
+from pydocstringformatter._utils.issue_template import create_gh_issue_template
 from pydocstringformatter._utils.output import print_to_console, sys_exit
 
 __all__ = [
@@ -18,6 +19,7 @@ __all__ = [
     "PydocstringFormatterError",
     "TomlParsingError",
     "UnstableResultError",
+    "create_gh_issue_template",
     "print_to_console",
     "sys_exit",
 ]

--- a/pydocstringformatter/_utils/__init__.py
+++ b/pydocstringformatter/_utils/__init__.py
@@ -2,6 +2,7 @@ from pydocstringformatter._utils.exceptions import (
     ParsingError,
     PydocstringFormatterError,
     TomlParsingError,
+    UnstableResultError,
 )
 from pydocstringformatter._utils.file_diference import compare_formatters, generate_diff
 from pydocstringformatter._utils.find_docstrings import is_docstring
@@ -16,6 +17,7 @@ __all__ = [
     "ParsingError",
     "PydocstringFormatterError",
     "TomlParsingError",
+    "UnstableResultError",
     "print_to_console",
     "sys_exit",
 ]

--- a/pydocstringformatter/_utils/exceptions.py
+++ b/pydocstringformatter/_utils/exceptions.py
@@ -12,3 +12,7 @@ class UnrecognizedOption(PydocstringFormatterError):
 
 class TomlParsingError(PydocstringFormatterError):
     """Raised when there are errors with the parsing of the toml file."""
+
+
+class UnstableResultError(PydocstringFormatterError):
+    """Raised when the result of the formatting is unstable."""

--- a/pydocstringformatter/_utils/issue_template.py
+++ b/pydocstringformatter/_utils/issue_template.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import tokenize
+
+from pydocstringformatter._formatting import Formatter
+from pydocstringformatter._utils.file_diference import compare_formatters
+
+
+def create_gh_issue_template(
+    token: tokenize.TokenInfo, formatters: dict[str, Formatter], filename: str
+) -> str:
+    """Make a template for a GitHub issue.
+
+    Args:
+        token: The token that caused the issue.
+        formatters: The formatters that caused the issue.
+        filename: The filename of the file that caused the issue.
+    """
+    formatter_names = list(formatters)
+    msg = ""
+    if len(formatter_names) > 2:
+        msg = f"""
+Conflicting formatters: {", ".join(formatters)}
+"""
+        diff = f"Diff too intricate to compute for {len(formatter_names)} formatters."
+    else:
+        if len(formatter_names) == 2:
+            msg = f"""
+Conflicting formatters: {" and ".join(formatter_names)}
+These formatters conflict with each other for:
+
+```python
+{token.string}
+```
+"""
+            formatter_1 = formatters[formatter_names[0]]
+            formatter_2 = formatters[formatter_names[1]]
+        else:
+            msg = f"""
+Formatter: {formatter_names[0]}
+This formatter is not able to make stable changes for:
+
+```python
+{token.string}
+```
+"""
+            formatter_1 = formatters[formatter_names[0]]
+            formatter_2 = formatter_1
+
+        diff = compare_formatters(
+            token,
+            formatter_1,
+            formatter_2,
+            title_extra=str(filename),
+        )
+
+    out = f"""
+Unfortunately an error occurred while formatting a docstring.
+Please help us fix this bug by opening an issue at:
+https://github.com/DanielNoord/pydocstringformatter/issues/new
+
+{"-" * 80}
+
+You can use the following template when you open the issue:
+
+# Description:
+
+{msg}
+
+# Diff:
+
+```diff
+{diff}
+```
+
+"""
+
+    return out

--- a/tests/data/format/linewrap_summary/function_docstrings.py.out
+++ b/tests/data/format/linewrap_summary/function_docstrings.py.out
@@ -1,5 +1,6 @@
 def func():
-    """A very long summary line that needs to be wrapped, A very long summary line that
+    """A very long summary line that needs to be wrapped, A very long summary line that.
+
     needs to be wrapped.
 
     A description that is not too long.
@@ -7,7 +8,8 @@ def func():
 
 
 def func():
-    """A very long multi-line summary line that needs to be wrapped, A very long multi-
+    """A very long multi-line summary line that needs to be wrapped, A very long multi-.
+
     line summary line that needs to be wrapped.
 
     A very long summary line that needs to be wrapped.
@@ -28,13 +30,15 @@ def func():
 # Since the ending quotes will be appended on the same line this
 # exceeds the max length.
 def func():
-    """A multi-line summary that can be on one line, Something that is just too
+    """A multi-line summary that can be on one line, Something that is just too.
+
     longgg.
     """
 
 
 def func():
-    """A multi-line summary that can be on one line, Something that is just too
+    """A multi-line summary that can be on one line, Something that is just too.
+
     long.
     """
 
@@ -46,6 +50,7 @@ def func():
 # Regression for bug found in pylint
 # We should re-add the quotes to line length if they will never be on the first line.
 class LinesChunk:
-    """The LinesChunk object computes and stores the hash of some consecutive stripped
+    """The LinesChunk object computes and stores the hash of some consecutive stripped.
+
     lines of a lineset.
     """

--- a/tests/test_conflicting_formatters.py
+++ b/tests/test_conflicting_formatters.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from pydocstringformatter import _formatting
+from pydocstringformatter import _testutils as test_utils
+from pydocstringformatter._formatting import Formatter
+from pydocstringformatter._utils import UnstableResultError
+from pydocstringformatter.run import _Run
+
+
+@contextmanager
+def patched_run(formatters: list[Formatter]) -> Generator[type[_Run], None, None]:
+    """Patches formatters so Run only uses the provided formatters."""
+    old_formatters = _formatting.FORMATTERS
+    _formatting.FORMATTERS = formatters
+    yield _Run
+    _formatting.FORMATTERS = old_formatters
+
+
+@pytest.mark.parametrize(
+    "formatters,expected_errors",
+    [
+        (
+            [test_utils.MakeAFormatter(), test_utils.MakeBFormatter()],
+            ["Conflicting formatters"],
+        ),
+        (
+            [test_utils.MakeBFormatter(), test_utils.AddBFormatter()],
+            ["not able to make stable changes"],
+        ),
+        (
+            [
+                test_utils.MakeBFormatter(),
+                test_utils.AddBFormatter(),
+                test_utils.MakeAFormatter(),
+            ],
+            ["Conflicting formatters:", "Diff too intricate to compute"],
+        ),
+    ],
+)
+def test_conflicting_formatters(
+    formatters: list[Formatter],
+    expected_errors: list[str],
+    tmp_path: Path,
+) -> None:
+    """Tests that conflicting formatters raise an error."""
+    tmp_file = tmp_path / "test.py"
+    with open(tmp_file, "w", encoding="utf-8") as f:
+        content = [
+            '"""AAA AA AAA"""',
+        ]
+        f.writelines(content)
+
+    with patched_run(formatters) as run:
+        with pytest.raises(UnstableResultError) as err:
+            run([str(tmp_file)])
+
+    for expect_err in expected_errors:
+        assert expect_err in str(err.value), str(err.value)


### PR DESCRIPTION
Discussed here:
https://github.com/DanielNoord/pydocstringformatter/issues/169

Things to iron out:
- [ ] should arguments be added to enable it? (--num-passes ... --no-check ????) .... I vote no arguments ...
- [x] should the error be more user-friendly?
- [ ] Regarding the failing tests ... option A. Fix the formatters so they become compatible, option B. Fix the tests so the incompatible formatters do not get called together (also change the defauts of just adding the --style"numpydoc" to prevent automatic collisions ...). LMK what you think.
- [x] testing ... Right not by "playing with it" it works but a better unit testing is required.

https://github.com/DanielNoord/pydocstringformatter/issues/169#issuecomment-1249090803

> I haven't looked at your branch as I am on mobile, but I'm highly in favour of this change. I'll gladly help review a PR but sadly won't have time to work on this myself this week.
> 
> Some pointers to consider:
> 
>     * I think the maximum run count should be 2.
> 
>     * After the second run, a third run should occur. If we still create changes (note that these should ignore the --write flag but should only check if there are any potential change) we need to emit an error. `black` has a very elegant system where after there is an inconsistency aftwr 2/3 runs a pre-regenerated bug report is send to stdout. This can then be copied to an issue in GitHub which would allow us to resolve the issue.
> 
>     * We should test the issue template. So we need to write two incompatible test formatters and write a test where they fail to find a solution.
> 
> 
> That's all I can think of for now. Let me know if you have any questions! 😊

- [ ] Issue template to report the problems

Current error:

```
>           raise RuntimeError(msg)
E           RuntimeError: Conflicting formatters: numpydoc-section-spacing, closing-quotes
E           --- numpydoc-section-spacing vs closing-quotes /private/var/folders/5j/x2qvf77j1m7736lccs2xt6c40000gn/T/pytest-of-sebastianpaez/pytest-187/test_formatting_numpydoc_numpy0/test_file.py
E           +++ numpydoc-section-spacing vs closing-quotes /private/var/folders/5j/x2qvf77j1m7736lccs2xt6c40000gn/T/pytest-of-sebastianpaez/pytest-187/test_formatting_numpydoc_numpy0/test_file.py
E           @@ -1,2 +1 @@
E           -"""A docstring.
E           -    """
E           +"""A docstring."""
```
