### PR TITLE
Add example formatters and a ``compare_formatter`` utility

### DIFF
--- a/pydocstringformatter/_testutils/__init__.py
+++ b/pydocstringformatter/_testutils/__init__.py
@@ -10,9 +10,8 @@ import pytest
 from pydocstringformatter import run_docstring_formatter
 from pydocstringformatter._formatting import Formatter
 from pydocstringformatter._testutils.example_formatters import (
-    AddBFormatter,
     MakeAFormatter,
-    MakeBFormatter,
+    MakeBFormatter
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -84,4 +83,4 @@ Temp file is '{self.file_to_format}'
         return None
 
 
-__all__ = ["FormatterAsserter", "MakeAFormatter", "MakeBFormatter", "AddBFormatter"]
+__all__ = ["FormatterAsserter", "MakeAFormatter", "MakeBFormatter"]

--- a/pydocstringformatter/_testutils/__init__.py
+++ b/pydocstringformatter/_testutils/__init__.py
@@ -9,6 +9,11 @@ import pytest
 
 from pydocstringformatter import run_docstring_formatter
 from pydocstringformatter._formatting import Formatter
+from pydocstringformatter._testutils.example_formatters import (
+    AddBFormatter,
+    MakeAFormatter,
+    MakeBFormatter,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -77,3 +82,6 @@ Temp file is '{self.file_to_format}'
         exc_tb: TracebackType | None,
     ) -> None:
         return None
+
+
+__all__ = ["FormatterAsserter", "MakeAFormatter", "MakeBFormatter", "AddBFormatter"]

--- a/pydocstringformatter/_testutils/__init__.py
+++ b/pydocstringformatter/_testutils/__init__.py
@@ -11,7 +11,7 @@ from pydocstringformatter import run_docstring_formatter
 from pydocstringformatter._formatting import Formatter
 from pydocstringformatter._testutils.example_formatters import (
     MakeAFormatter,
-    MakeBFormatter
+    MakeBFormatter,
 )
 
 LOGGER = logging.getLogger(__name__)

--- a/pydocstringformatter/_testutils/example_formatters.py
+++ b/pydocstringformatter/_testutils/example_formatters.py
@@ -1,0 +1,42 @@
+import tokenize
+
+from pydocstringformatter._formatting import Formatter
+
+
+class MakeAFormatter(Formatter):
+    """A formatter that makes Bs into As."""
+
+    name = "make-a-formatter"
+    style = ["default"]
+
+    def treat_token(self, tokeninfo: tokenize.TokenInfo) -> tokenize.TokenInfo:
+        """Replace Bs with As."""
+        token_dict = tokeninfo._asdict()
+        token_dict["string"] = token_dict["string"].replace("B", "A")
+        return type(tokeninfo)(**token_dict)
+
+
+class MakeBFormatter(Formatter):
+    """A formatter that makes As into Bs."""
+
+    name = "make-b-formatter"
+    style = ["default"]
+
+    def treat_token(self, tokeninfo: tokenize.TokenInfo) -> tokenize.TokenInfo:
+        """Replace As with Bs."""
+        token_dict = tokeninfo._asdict()
+        token_dict["string"] = token_dict["string"].replace("A", "B")
+        return type(tokeninfo)(**token_dict)
+
+
+class AddBFormatter(Formatter):
+    """A formatter that adds Bs."""
+
+    name = "add-b-formatter"
+    style = ["default"]
+
+    def treat_token(self, tokeninfo: tokenize.TokenInfo) -> tokenize.TokenInfo:
+        """Add a B to the end of the string."""
+        token_dict = tokeninfo._asdict()
+        token_dict["string"] += "B"
+        return type(tokeninfo)(**token_dict)

--- a/pydocstringformatter/_testutils/example_formatters.py
+++ b/pydocstringformatter/_testutils/example_formatters.py
@@ -27,16 +27,3 @@ class MakeBFormatter(Formatter):
         token_dict = tokeninfo._asdict()
         token_dict["string"] = token_dict["string"].replace("A", "B")
         return type(tokeninfo)(**token_dict)
-
-
-class AddBFormatter(Formatter):
-    """A formatter that adds Bs."""
-
-    name = "add-b-formatter"
-    style = ["default"]
-
-    def treat_token(self, tokeninfo: tokenize.TokenInfo) -> tokenize.TokenInfo:
-        """Add a B to the end of the string."""
-        token_dict = tokeninfo._asdict()
-        token_dict["string"] += "B"
-        return type(tokeninfo)(**token_dict)

--- a/pydocstringformatter/_utils/__init__.py
+++ b/pydocstringformatter/_utils/__init__.py
@@ -3,13 +3,14 @@ from pydocstringformatter._utils.exceptions import (
     PydocstringFormatterError,
     TomlParsingError,
 )
-from pydocstringformatter._utils.file_diference import generate_diff
+from pydocstringformatter._utils.file_diference import compare_formatters, generate_diff
 from pydocstringformatter._utils.find_docstrings import is_docstring
 from pydocstringformatter._utils.find_python_file import find_python_files
 from pydocstringformatter._utils.output import print_to_console, sys_exit
 
 __all__ = [
     "find_python_files",
+    "compare_formatters",
     "generate_diff",
     "is_docstring",
     "ParsingError",

--- a/pydocstringformatter/_utils/file_diference.py
+++ b/pydocstringformatter/_utils/file_diference.py
@@ -1,4 +1,7 @@
 import difflib
+import tokenize
+
+from pydocstringformatter._formatting import Formatter
 
 
 def generate_diff(old: str, new: str, filename: str) -> str:
@@ -15,3 +18,19 @@ def generate_diff(old: str, new: str, filename: str) -> str:
         )
         + "\n"
     )
+
+
+def compare_formatters(
+    token: tokenize.TokenInfo,
+    formatter_1: Formatter,
+    formatter_2: Formatter,
+    title_extra: str = "",
+) -> str:
+    """Modifies a token with two formatters and returns the difference."""
+    out_t1 = formatter_1.treat_token(token)
+    out_t2 = formatter_2.treat_token(out_t1)
+
+    title = f"{formatter_1.name} vs {formatter_2.name}"
+    if title_extra:
+        title += f" {title_extra}"
+    return generate_diff(out_t1.string, out_t2.string, title)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,12 @@ from pathlib import Path
 import pytest
 
 import pydocstringformatter
-from pydocstringformatter._utils import find_python_files, is_docstring
+from pydocstringformatter._testutils import MakeAFormatter, MakeBFormatter
+from pydocstringformatter._utils import (
+    compare_formatters,
+    find_python_files,
+    is_docstring,
+)
 
 HERE = Path(__file__)
 UTILS_DATA = HERE.parent / "data" / "utils"
@@ -157,3 +162,21 @@ def test_encoding_of_console_messages(
     output = capsys.readouterr()
     assert output.out == "Nothing to do! All docstrings in 1 file are correct 🎉\n"
     assert not output.err
+
+
+def test_formatter_comparer() -> None:
+    """Test the compare_formatters utility function."""
+    tokeninfo = tokenize.TokenInfo(
+        1, '"""AAA AA AAA"""', (1, 0), (1, 0), '"""AAA AA AAA"""'
+    )
+
+    diff = compare_formatters(tokeninfo, MakeAFormatter(), MakeBFormatter(), "test")
+
+    expected_sections = [
+        "--- make-a-formatter vs make-b-formatter test\n",
+        '-"""AAA AA AAA"""\n',
+        '+"""BBB BB BBB"""\n',
+    ]
+
+    for section in expected_sections:
+        assert section in diff


### PR DESCRIPTION
Based on work in https://github.com/DanielNoord/pydocstringformatter/pull/173 by @jspaezp