### PR TITLE
Fix regex to deal with mixing of quotes at start of string

### DIFF
--- a/pydocstringformatter/_formatting/base.py
+++ b/pydocstringformatter/_formatting/base.py
@@ -73,7 +73,7 @@ class StringFormatter(Formatter):
 class StringAndQuotesFormatter(Formatter):
     """Base class for string formatter that needs access to the quotes."""
 
-    quotes_regex = re.compile(r"""['"]{1,3}""")
+    quotes_regex = re.compile(r"""^('{3}|'|"{3}|")""")
     """Pattern to match against opening quotes."""
 
     @abc.abstractmethod

--- a/tests/data/format/quotes_type/mix_with_double_at_start.py
+++ b/tests/data/format/quotes_type/mix_with_double_at_start.py
@@ -1,0 +1,11 @@
+def a(self):
+    "'a.m.' or 'p.m.'"
+
+def b(self):
+    """'a.m.' or 'p.m.'"""
+
+def c(self):
+    "'''a.m.''' or 'p.m.'"
+
+def d(self):
+    """'''a.m.''' or 'p.m.'"""

--- a/tests/data/format/quotes_type/mix_with_double_at_start.py.out
+++ b/tests/data/format/quotes_type/mix_with_double_at_start.py.out
@@ -1,0 +1,11 @@
+def a(self):
+    """'A.m.' or 'p.m.'."""
+
+def b(self):
+    """'a.m.' or 'p.m.'."""
+
+def c(self):
+    """'''a.m.''' or 'p.m.'."""
+
+def d(self):
+    """'''a.m.''' or 'p.m.'."""

--- a/tests/data/format/quotes_type/mix_with_single_at_start.py
+++ b/tests/data/format/quotes_type/mix_with_single_at_start.py
@@ -1,0 +1,11 @@
+def a(self):
+    '"a.m." or "p.m."'
+
+def b(self):
+    '''"a.m." or "p.m."'''
+
+def c(self):
+    '"""a.m.""" or "p.m."'
+
+def d(self):
+    '''"""a.m.""" or "p.m."'''

--- a/tests/data/format/quotes_type/mix_with_single_at_start.py.out
+++ b/tests/data/format/quotes_type/mix_with_single_at_start.py.out
@@ -1,0 +1,11 @@
+def a(self):
+    """"A.m." or "p.m."."""
+
+def b(self):
+    """"a.m." or "p.m."."""
+
+def c(self):
+    """"""a.m.""" or "p.m."."""
+
+def d(self):
+    """"""a.m.""" or "p.m."."""


### PR DESCRIPTION
Closes https://github.com/DanielNoord/pydocstringformatter/issues/489

I guess that regex was always doomed to fail.

This should fix it. There are some weird changes that I don't particularly like.

For example, capitalization in `"""'A.m.' or 'p.m.'."""` is not desired I think...
Also `""""""a.m.""" or "p.m."."""` is invalid syntax.

However, we have always said that we can't format everything perfectly and "crap in is crap out". Since this at least fixes the bug I think it is still an improvement.