### PR TITLE
Bump sphinx and types-docutils in mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
         args: [--config-file=pyproject.toml]
         exclude: *test-data
         additional_dependencies:
-          [pytest-stub==1.1.0, types-docutils~=0.17.5, sphinx~=4.4]
+          [pytest-stub==1.1.0, types-docutils~=0.22.3, sphinx~=9.0.4]
   - repo: https://github.com/DanielNoord/pydocstringformatter
     rev: v1.0.0
     hooks:


### PR DESCRIPTION
`additional_dependencies` of the mypy hook still pinned `sphinx~=4.4` and `types-docutils~=0.17.5`. Dependabot does not track pins inside `.pre-commit-config.yaml`, so they drifted years behind `docs/requirements-doc.txt` (now `sphinx~=9.0.4`, see #575).

`docs/_ext/usage_page.py` imports `sphinx.application`, and pre-commit passes filenames explicitly (overriding `files = "pydocstringformatter,tests"` in `pyproject.toml`), so that file was being type-checked against stale sphinx types.

Verified locally: `pre-commit run mypy --all-files` passes with mypy `strict = true` and `enable_error_code = "ignore-without-code"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)